### PR TITLE
Increased the number of test cases for the parser

### DIFF
--- a/tests/TestScript.hs
+++ b/tests/TestScript.hs
@@ -67,9 +67,11 @@ scriptPropTests
   = testGroup "Parser and Pretty Printer Tests"
     [ localOption (QuickCheckMaxSize 8) $
       parserRoundtripTest "lit == parse (ppr lit)" Parser.parseLit
-    , localOption (QuickCheckMaxSize 8) $
+    , localOption (QuickCheckTests  10000) $
+      localOption (QuickCheckMaxSize 8) $
       parserRoundtripTest "expr == parse (ppr expr)" Parser.parseExpr
-    , localOption (QuickCheckMaxSize 4) $
+    , localOption (QuickCheckTests 10000) $
+      localOption (QuickCheckMaxSize 4) $
       parserRoundtripTest "script == parse (ppr script)" Parser.parseScript
     , testProperty "decimal == parse (ppr decimal)" $ \lit ->
         (case lit of LNum _ -> True; _ -> False) ==>


### PR DESCRIPTION
There is a bug in the parser which sometimes can evade the QuickCheck tests. The number of test cases for the parser has been radically increased, the error should no longer sneak by.