### PR TITLE
Generalizing safe workflows

### DIFF
--- a/src/Language/FCL/WorkflowNet.hs
+++ b/src/Language/FCL/WorkflowNet.hs
@@ -144,6 +144,7 @@ fireUnsafe
   -> Transition a
   -> Marking a
 fireUnsafe marking (Transition f _ inputs outputs) =
+    -- NOTE: these are disjoint maps --> \/ is just a union
     Map.fromSet outputToken outputs \/ remainingMarkings
   where
     remainingMarkings :: Marking a
@@ -166,6 +167,8 @@ fireUnsafe marking (Transition f _ inputs outputs) =
     outputToken :: Place -> Token a
     outputToken = const (f inputEnv)
 
+-- | Fires all the enabled transitions independently,
+-- and returns the resulting markings.
 fireEnabledTransitions
   :: (Ord a, JoinSemiLattice a)
   => Marking a

--- a/tests/Test/Undefinedness.hs
+++ b/tests/Test/Undefinedness.hs
@@ -12,7 +12,6 @@ import Test.Tasty.QuickCheck
 import Language.FCL.AST (Loc())
 import Language.FCL.Undefinedness
 
--- QUESTION: Why do we only generate empty errors?
 instance Arbitrary IsInitialized where
   arbitrary = oneof
     [ pure Initialized
@@ -66,8 +65,8 @@ semilattice testName op bound = testGroup testName
 undefinednessTests :: TestTree
 undefinednessTests
   = testGroup "Undefinedness tests"
-    [ boundedSemilattice "IsInitialized is a bounded meet semilattice)" (/\) Initialized
-    , semilattice "IsInitialized is a join semilattice)" (\/) (Error mempty)
+    [ semilattice "IsInitialized is a join semilattice)" (\/) (Error mempty)
+    , boundedSemilattice "IsInitialized is a bounded meet semilattice)" (/\) Initialized
     , testProperty "IsInitialized has join-meet-absorption" $ absorbs @IsInitialized (\/) (/\)
     , testProperty "IsInitialized has meet-join-absorption" $ absorbs @IsInitialized (/\) (\/)
     ]

--- a/tests/Test/Workflow/SafeWorkflow.hs
+++ b/tests/Test/Workflow/SafeWorkflow.hs
@@ -86,33 +86,41 @@ data SafeWorkflow
   | Atom
   deriving (Eq, Ord, Show, Generic, NFData)
 
--- TODO: redefine tehse using record pattern synonyms: https://gitlab.haskell.org/ghc/ghc/wikis/pattern-synonyms/record-pattern-synonyms
+-- TODO: redefine these using record pattern synonyms: https://gitlab.haskell.org/ghc/ghc/wikis/pattern-synonyms/record-pattern-synonyms
 
 -- | XOR with two branches.
+pattern XOR :: SafeWorkflow -> SafeWorkflow -> SafeWorkflow
 pattern XOR lhs rhs <- GenACF' (M.toList -> [(GACFArrow Entry Exit, [lhs, rhs])])
   where XOR lhs rhs  = GenACF' (M.fromList  [(GACFArrow Entry Exit, [lhs, rhs])])
 
 -- | XOR with three branches.
+pattern XOR3 :: SafeWorkflow -> SafeWorkflow -> SafeWorkflow -> SafeWorkflow
 pattern XOR3 a b c   = XOR a (XOR b c)
 
 -- | XOR with unidirectional communication between branches.
+pattern GenXOR :: SafeWorkflow -> SafeWorkflow -> SafeWorkflow -> SafeWorkflow -> SafeWorkflow -> SafeWorkflow
 pattern GenXOR lhsIn lhsOut rhsIn rhsOut lhsToRhs <- GenACF' (M.toList -> [(GACFArrow Entry (P 1), [lhsIn]), (GACFArrow (P 1) Exit, [lhsOut]), (GACFArrow Entry (P 2), [rhsIn]), (GACFArrow (P 2) Exit, [rhsOut]), (GACFArrow (P 1) (P 2), [lhsToRhs])])
   where GenXOR lhsIn lhsOut rhsIn rhsOut lhsToRhs =  GenACF' (M.fromList  [(GACFArrow Entry (P 1), [lhsIn]), (GACFArrow (P 1) Exit, [lhsOut]), (GACFArrow Entry (P 2), [rhsIn]), (GACFArrow (P 2) Exit, [rhsOut]), (GACFArrow (P 1) (P 2), [lhsToRhs])])
 
 -- | Sequencing two safe workflows.
+pattern Seq :: SafeWorkflow -> SafeWorkflow -> SafeWorkflow
 pattern Seq lhs rhs <- GenACF' (M.toList -> [(GACFArrow Entry (P 1), [lhs]), (GACFArrow (P 1) Exit, [rhs])])
   where Seq lhs rhs =  GenACF' (M.fromList  [(GACFArrow Entry (P 1), [lhs]), (GACFArrow (P 1) Exit, [rhs])])
 
 -- | Unidirectional pattern general acyclic control-flow.
+pattern GenACF :: Map GACFArrow [SafeWorkflow] -> SafeWorkflow
 pattern GenACF m <- GenACF' m
 
 -- | AND with two branches.
+pattern AND2 :: SafeWorkflow -> SafeWorkflow -> SafeWorkflow
 pattern AND2 lhs rhs = AND (lhs :| [rhs])
 
 -- | Simple loop with exit only from the head.
+pattern SimpleLoop :: SafeWorkflow -> SafeWorkflow -> SafeWorkflow
 pattern SimpleLoop loop exit = GenLoop Nothing exit loop
 
 -- | Loop with exit from the body.
+pattern Loop :: SafeWorkflow -> SafeWorkflow -> SafeWorkflow -> SafeWorkflow
 pattern Loop loopIn exit loopOut = GenLoop (Just loopIn) exit loopOut
 
 xorLhs :: SafeWorkflow -> SafeWorkflow

--- a/tests/Test/Workflow/SafeWorkflow.hs
+++ b/tests/Test/Workflow/SafeWorkflow.hs
@@ -5,11 +5,29 @@
 {-# LANGUAGE ViewPatterns #-}
 module Test.Workflow.SafeWorkflow
   ( SafeWorkflow(..)
+
+  , pattern XOR
   , pattern XOR3
+  , pattern GenXOR
   , pattern AND2
+  , pattern Seq
   , pattern SimpleLoop
   , pattern Loop
+
+  , xorLhs
+  , xorRhs
+  , gXorLhsIn
+  , gXorLhsOut
+  , gXorRhsIn
+  , gXorRhsOut
+  , gXorLhsToRhs
+  , seqLhs
+  , seqRhs
+
   , constructTransitions
+
+  , SWArrow(..)
+  , SWPlace(..)
   ) where
 
 import Protolude
@@ -35,9 +53,8 @@ import Language.FCL.Orphans()
 
 -- NOTE: can't return back to different places from a loop (eg.: novation.s)
 -- NOTE: syncronisation points are always singleton states (places) (eg.: novation.s)
--- NOTE: there is a loop hidden inside GenXOR
--- NOTE: GenXOR lhsIn lhsOut rhsIn rhsOut Nothing Nothing is equivalent to
---       XOR (Seq lhsIn lhsOut) (Seq rhsIn rhsOut)
+-- NOTE: safe workflows are always progressive, you can't jump into a loop (loops are isolated)
+--       GenXOR allowed this, but GenACF does not
 
 data SWPlace = Entry  -- ^ Entry point to this sub-workflow.
              | P Int  -- ^ Labelled intermediate place.
@@ -62,28 +79,56 @@ data SafeWorkflow
             , gLoopOut  :: SafeWorkflow           -- ^ Seconds half of the body of the loop
             }
   -- | Generalized acyclic control-flow.
-  | GenACF { gACFMap :: Map SWArrow SafeWorkflow
+  | GenACF { gACFMap :: Map SWArrow [SafeWorkflow]
            }
   -- | Atom representing a single transition.
   | Atom
   deriving (Eq, Ord, Show, Generic, NFData)
 
+-- TODO: redefine tehse using record pattern synonyms: https://gitlab.haskell.org/ghc/ghc/wikis/pattern-synonyms/record-pattern-synonyms
 -- | XOR with two branches.
-pattern XOR lhs rhs <- GenACF (M.toList -> [(SWArrow Entry Exit, lhs), (SWArrow Entry Exit, rhs)])
-  where XOR lhs rhs  = GenACF (M.fromList  [(SWArrow Entry Exit, lhs), (SWArrow Entry Exit, rhs)])
+pattern XOR lhs rhs <- GenACF (M.toList -> [(SWArrow Entry Exit, [lhs, rhs])])
+  where XOR lhs rhs  = GenACF (M.fromList  [(SWArrow Entry Exit, [lhs, rhs])])
 -- | XOR with three branches.
 pattern XOR3 a b c   = XOR a (XOR b c)
 -- | XOR with unidirectional communication between branches.
-pattern GenXOR lhsIn lhsOut rhsIn rhsOut lhsToRhs <- GenACF (M.toList -> [(SWArrow Entry (P 1), lhsIn), (SWArrow (P 1) Exit, lhsOut), (SWArrow Entry (P 2), rhsIn), (SWArrow (P 2) Exit, rhsOut), (SWArrow (P 1) (P 2), lhsToRhs)])
-  where GenXOR lhsIn lhsOut rhsIn rhsOut lhsToRhs =  GenACF (M.fromList  [(SWArrow Entry (P 1), lhsIn), (SWArrow (P 1) Exit, lhsOut), (SWArrow Entry (P 2), rhsIn), (SWArrow (P 2) Exit, rhsOut), (SWArrow (P 1) (P 2), lhsToRhs)])
+pattern GenXOR lhsIn lhsOut rhsIn rhsOut lhsToRhs <- GenACF (M.toList -> [(SWArrow Entry (P 1), [lhsIn]), (SWArrow (P 1) Exit, [lhsOut]), (SWArrow Entry (P 2), [rhsIn]), (SWArrow (P 2) Exit, [rhsOut]), (SWArrow (P 1) (P 2), [lhsToRhs])])
+  where GenXOR lhsIn lhsOut rhsIn rhsOut lhsToRhs =  GenACF (M.fromList  [(SWArrow Entry (P 1), [lhsIn]), (SWArrow (P 1) Exit, [lhsOut]), (SWArrow Entry (P 2), [rhsIn]), (SWArrow (P 2) Exit, [rhsOut]), (SWArrow (P 1) (P 2), [lhsToRhs])])
 -- | AND with two branches.
-pattern Seq lhs rhs <- GenACF (M.toList -> [(SWArrow Entry (P 1), lhs), (SWArrow (P 1) Exit, rhs)])
-  where Seq lhs rhs =  GenACF (M.fromList  [(SWArrow Entry (P 1), lhs), (SWArrow (P 1) Exit, rhs)])
+pattern Seq lhs rhs <- GenACF (M.toList -> [(SWArrow Entry (P 1), [lhs]), (SWArrow (P 1) Exit, [rhs])])
+  where Seq lhs rhs =  GenACF (M.fromList  [(SWArrow Entry (P 1), [lhs]), (SWArrow (P 1) Exit, [rhs])])
 pattern AND2 lhs rhs = AND (lhs :| [rhs])
 -- | Simple loop with exit only from the head.
 pattern SimpleLoop loop   exit         = GenLoop Nothing       exit loop
 -- | Loop with exit from the body.
 pattern Loop       loopIn exit loopOut = GenLoop (Just loopIn) exit loopOut
+
+xorLhs :: SafeWorkflow -> SafeWorkflow
+xorLhs (XOR lhs _) = lhs
+
+xorRhs :: SafeWorkflow -> SafeWorkflow
+xorRhs (XOR _ rhs) = rhs
+
+gXorLhsIn :: SafeWorkflow -> SafeWorkflow
+gXorLhsIn (GenXOR lhsIn _ _ _ _) = lhsIn
+
+gXorLhsOut :: SafeWorkflow -> SafeWorkflow
+gXorLhsOut (GenXOR _ lhsOut _ _ _) = lhsOut
+
+gXorRhsIn :: SafeWorkflow -> SafeWorkflow
+gXorRhsIn (GenXOR _ _ rhsIn _ _) = rhsIn
+
+gXorRhsOut :: SafeWorkflow -> SafeWorkflow
+gXorRhsOut (GenXOR _ _ _ rhsOut _) = rhsOut
+
+gXorLhsToRhs :: SafeWorkflow -> SafeWorkflow
+gXorLhsToRhs (GenXOR _ _ _ _ lhsToRhs) = lhsToRhs
+
+seqLhs :: SafeWorkflow -> SafeWorkflow
+seqLhs (Seq lhs _) = lhs
+
+seqRhs :: SafeWorkflow -> SafeWorkflow
+seqRhs (Seq _ rhs) = rhs
 
 isIntermediate :: SWPlace -> Bool
 isIntermediate (P _) = True
@@ -141,10 +186,10 @@ constructTransitionsM start end (GenACF acf) = do
       getState Entry = start
       getState Exit  = end
       getState p     = fromMaybe (panic $ "constructTransitionsM: Place " <> show p <> " is not present in state map.") $ M.lookup p stateMap
-  forM_ acfList $ \(SWArrow from to, swf) -> do
+  forM_ acfList $ \(SWArrow from to, swfs) -> do
     let from' = getState from
         to'   = getState to
-    constructTransitionsM from' to' swf
+    mapM_ (constructTransitionsM from' to') swfs
 constructTransitionsM start end Atom = do
   tell [Arrow start end]
 

--- a/tests/Test/Workflow/SafeWorkflow.hs
+++ b/tests/Test/Workflow/SafeWorkflow.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveGeneric, DeriveAnyClass #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE ViewPatterns #-}
 module Test.Workflow.SafeWorkflow
   ( SafeWorkflow(..)
   , pattern XOR3
@@ -15,8 +16,12 @@ import Protolude
 
 import Data.Maybe (fromJust)
 import Data.Set (Set(..))
+import Data.Map (Map(..))
 import Data.List.NonEmpty (NonEmpty(..))
+import Data.List (nub)
+
 import qualified Data.Set as S
+import qualified Data.Map as M
 import qualified Data.List.NonEmpty as NE
 
 import Control.Monad.Gen
@@ -34,20 +39,21 @@ import Language.FCL.Orphans()
 -- NOTE: GenXOR lhsIn lhsOut rhsIn rhsOut Nothing Nothing is equivalent to
 --       XOR (Seq lhsIn lhsOut) (Seq rhsIn rhsOut)
 
+data SWPlace = Entry  -- ^ Entry point to this sub-workflow.
+             | P Int  -- ^ Labelled intermediate place.
+             | Exit   -- ^ Exit point rom this sub-workflow.
+  deriving (Eq, Ord, Show, Generic, NFData, Arbitrary) -- TODO: remove Arbitrary
+
+data SWArrow = SWArrow SWPlace SWPlace
+  deriving (Eq, Ord, Show, Generic, NFData, Arbitrary) -- TODO: remove Arbitrary
+
 -- | Workflow nets that are sound by construction. We only allow these _safe_ workflow nets
 -- to be constructed in very specific ways in order to make soundness verification automatic.
 data SafeWorkflow
   -- TODO: should be List2 instead
+  -- TODO: branc in the comment
   -- | AND splitting into multiple workflows.
   = AND { andBranches :: NonEmpty SafeWorkflow    -- ^ At least one branc
-        }
-  -- | XOR splitting into two workflows.
-  | XOR { xorLhs :: SafeWorkflow                  -- ^ Left XOR branch
-        , xorRhs :: SafeWorkflow                  -- ^ Right XOR branch
-        }
-  -- |  Sequencing two workflow.
-  | Seq { seqLhs :: SafeWorkflow                  -- ^ First workflow
-        , seqRhs :: SafeWorkflow                  -- ^ Second workflow
         }
   -- | Looping construct with option to exit from both the body of the loop and the head of the loop.
   -- If the first half of the body is empty, we exit from head, otherwise exit from the body.
@@ -55,27 +61,33 @@ data SafeWorkflow
             , gLoopExit :: SafeWorkflow           -- ^ Exit from the loop
             , gLoopOut  :: SafeWorkflow           -- ^ Seconds half of the body of the loop
             }
-  -- | General XOR split with the possibility of moving between the branches.
-  | GenXOR { gXorLhsIn   :: SafeWorkflow          -- ^ First half of left-hand side
-           , gXorLhsOut  :: SafeWorkflow          -- ^ Second half of left-hand side
-           , gXorRhsIn   :: SafeWorkflow          -- ^ First half of right-hand side
-           , gXorRhsOut  :: SafeWorkflow          -- ^ Second half of right-hand side
-           , gXorMToRhs  :: (Maybe SafeWorkflow)  -- ^ Moving to the right-hand side from the left one
-           , gXorMToLhs  :: (Maybe SafeWorkflow)  -- ^ Moving to the left-hand side from the right one
+  -- | Generalized acyclic control-flow.
+  | GenACF { gACFMap :: Map SWArrow SafeWorkflow
            }
   -- | Atom representing a single transition.
   | Atom
   deriving (Eq, Ord, Show, Generic, NFData)
 
-{-# COMPLETE XOR, AND, Seq, SimpleLoop, Loop, GenXOR #-}
+-- | XOR with two branches.
+pattern XOR lhs rhs <- GenACF (M.toList -> [(SWArrow Entry Exit, lhs), (SWArrow Entry Exit, rhs)])
+  where XOR lhs rhs  = GenACF (M.fromList  [(SWArrow Entry Exit, lhs), (SWArrow Entry Exit, rhs)])
 -- | XOR with three branches.
 pattern XOR3 a b c   = XOR a (XOR b c)
+-- | XOR with unidirectional communication between branches.
+pattern GenXOR lhsIn lhsOut rhsIn rhsOut lhsToRhs <- GenACF (M.toList -> [(SWArrow Entry (P 1), lhsIn), (SWArrow (P 1) Exit, lhsOut), (SWArrow Entry (P 2), rhsIn), (SWArrow (P 2) Exit, rhsOut), (SWArrow (P 1) (P 2), lhsToRhs)])
+  where GenXOR lhsIn lhsOut rhsIn rhsOut lhsToRhs =  GenACF (M.fromList  [(SWArrow Entry (P 1), lhsIn), (SWArrow (P 1) Exit, lhsOut), (SWArrow Entry (P 2), rhsIn), (SWArrow (P 2) Exit, rhsOut), (SWArrow (P 1) (P 2), lhsToRhs)])
 -- | AND with two branches.
+pattern Seq lhs rhs <- GenACF (M.toList -> [(SWArrow Entry (P 1), lhs), (SWArrow (P 1) Exit, rhs)])
+  where Seq lhs rhs =  GenACF (M.fromList  [(SWArrow Entry (P 1), lhs), (SWArrow (P 1) Exit, rhs)])
 pattern AND2 lhs rhs = AND (lhs :| [rhs])
 -- | Simple loop with exit only from the head.
 pattern SimpleLoop loop   exit         = GenLoop Nothing       exit loop
 -- | Loop with exit from the body.
 pattern Loop       loopIn exit loopOut = GenLoop (Just loopIn) exit loopOut
+
+isIntermediate :: SWPlace -> Bool
+isIntermediate (P _) = True
+isIntermediate _     = False
 
 -- | Make a workflow state from a `Name`.
 singletonWfState :: Name -> WorkflowState
@@ -105,9 +117,6 @@ constructTransitionsM start end (AND branches) = do
     pure (inSt, outSt)
   let (ins, outs) = unzip inOuts
   tell [Arrow start (mconcat ins), Arrow (mconcat outs) end]
-constructTransitionsM start end (XOR lhs rhs) = do
-  constructTransitionsM start end lhs
-  constructTransitionsM start end rhs
 constructTransitionsM start end (Seq lhs rhs) = do
   inBetween <- genWfState
   constructTransitionsM start inBetween lhs
@@ -120,30 +129,35 @@ constructTransitionsM start end (Loop gLoopIn exit gLoopOut) = do
   constructTransitionsM start inBetween gLoopIn
   constructTransitionsM inBetween end   exit
   constructTransitionsM inBetween start gLoopOut
-constructTransitionsM start end GenXOR{..} = do
-  lhsP <- genWfState
-  rhsP <- genWfState
-  constructTransitionsM start lhsP gXorLhsIn
-  constructTransitionsM lhsP  end  gXorLhsOut
-  constructTransitionsM start rhsP gXorRhsIn
-  constructTransitionsM rhsP  end  gXorRhsOut
-  when (isJust gXorMToRhs) $
-    constructTransitionsM lhsP rhsP (fromJust gXorMToRhs)
-  when (isJust gXorMToLhs) $
-    constructTransitionsM rhsP lhsP (fromJust gXorMToLhs)
+constructTransitionsM start end (GenACF acf) = do
+  let acfList = M.toList acf
+      acfPlaces = S.fromList
+                . filter isIntermediate
+                . concatMap (\(SWArrow x y) -> [x,y])
+                . map fst
+                $ acfList
+  stateMap <- sequence $ M.fromSet (const genWfState) acfPlaces
+  let getState :: SWPlace -> WorkflowState
+      getState Entry = start
+      getState Exit  = end
+      getState p     = fromMaybe (panic $ "constructTransitionsM: Place " <> show p <> " is not present in state map.") $ M.lookup p stateMap
+  forM_ acfList $ \(SWArrow from to, swf) -> do
+    let from' = getState from
+        to'   = getState to
+    constructTransitionsM from' to' swf
 constructTransitionsM start end Atom = do
   tell [Arrow start end]
 
+-- TODO: add genACF generation
 instance Arbitrary SafeWorkflow where
   arbitrary = sized genSWFNet where
     -- | Sized `SafeWorkflow generation
     genSWFNet :: Int -> QC.Gen SafeWorkflow
     genSWFNet n |          n <= 1 = atom
-    genSWFNet n | 1 < n && n <= 2 = complexity 2
-    genSWFNet n | 2 < n && n <= 3 = complexity 3
-    genSWFNet n | 3 < n && n <= 4 = complexity 4
-    genSWFNet n | 4 < n && n <= 5 = complexity 5
-    genSWFNet n | 5 < n           = oneof (allComplexities n)
+    genSWFNet n | 1 < n && n <= 2 = maxComplexity 2
+    genSWFNet n | 2 < n && n <= 3 = maxComplexity 3
+    genSWFNet n | 3 < n && n <= 4 = maxComplexity 4
+    genSWFNet n | 4 < n           = maxComplexity 5
     genSWFNet n = panic $ "Negative value for SafeWorkflow generation: " <> show n
 
     partitionThen :: Int -> Int -> ([Int] -> QC.Gen a) -> QC.Gen a
@@ -155,11 +169,11 @@ instance Arbitrary SafeWorkflow where
           aPartition <- elements partitions
           g aPartition
 
-    complexity :: Int -> QC.Gen SafeWorkflow
-    complexity n = oneof $ take n (allComplexities n)
+    maxComplexity :: Int -> QC.Gen SafeWorkflow
+    maxComplexity n = oneof $ take n (allComplexities n)
 
     allComplexities :: Int -> [QC.Gen SafeWorkflow]
-    allComplexities n = [ atom, complexity2 n, complexity3 n, complexity4 n, complexity5 n, complexity6 n ]
+    allComplexities n = [ atom, complexity2 n, complexity3 n, complexity4 n, complexity5 n ]
 
     atom :: QC.Gen SafeWorkflow
     atom = pure Atom
@@ -188,12 +202,6 @@ instance Arbitrary SafeWorkflow where
       case partition of
         [k1,k2,k3,k4] -> oneof
           [ AND <$> someSWFNets (n-2) 2
-          , GenXOR <$> genSWFNet k1
-                   <*> genSWFNet k2
-                   <*> genSWFNet k3
-                   <*> genSWFNet k4
-                   <*> pure Nothing
-                   <*> pure Nothing
           ]
         _ -> panic $ show n <> " was not partitioned into 4 components"
 
@@ -206,29 +214,9 @@ instance Arbitrary SafeWorkflow where
                    <*> genSWFNet k2
                    <*> genSWFNet k3
                    <*> genSWFNet k4
-                   <*> mGenSWFNet k5
-                   <*> pure Nothing
-          , GenXOR <$> genSWFNet k1
-                   <*> genSWFNet k2
-                   <*> genSWFNet k3
-                   <*> genSWFNet k4
-                   <*> pure Nothing
-                   <*> mGenSWFNet k5
+                   <*> genSWFNet k5
           ]
         _ -> panic $ show n <> " was not partitioned into 5 components"
-
-    complexity6 :: Int -> QC.Gen SafeWorkflow
-    complexity6 n = partitionThen n 6 $ \partition -> do
-      case partition of
-        [k1,k2,k3,k4,k5,k6] -> oneof
-          [ GenXOR <$> genSWFNet k1
-                   <*> genSWFNet k2
-                   <*> genSWFNet k3
-                   <*> genSWFNet k4
-                   <*> mGenSWFNet k5
-                   <*> mGenSWFNet k6
-          ]
-        _ -> panic $ show n <> " was not partitioned into 6 components"
 
     -- | Generates `SafeWorkflow`s of summed size `n`.
     someSWFNets :: Int -> Int -> QC.Gen (NonEmpty SafeWorkflow)
@@ -236,10 +224,6 @@ instance Arbitrary SafeWorkflow where
       partitionThen n k $ \ps -> do
         xs <- mapM genSWFNet ps
         pure $ NE.fromList xs
-
-    -- | Sized `Maybe SafeWorkflow` generation
-    mGenSWFNet :: Int -> QC.Gen (Maybe SafeWorkflow)
-    mGenSWFNet n = resize n (arbitrary @(Maybe SafeWorkflow))
 
     partitionInt d = go d d where
       go _  0  = [[]]

--- a/tests/Test/Workflow/SafeWorkflow.hs
+++ b/tests/Test/Workflow/SafeWorkflow.hs
@@ -6,6 +6,11 @@
 module Test.Workflow.SafeWorkflow
   ( SafeWorkflow(Atom, AND, GenLoop)
 
+  , andBranches
+
+  , mkGenACF
+  , unsafeMkGenACF
+
   , pattern XOR
   , pattern XOR3
   , pattern GenXOR

--- a/tests/Test/Workflow/SafeWorkflow/Debug.hs
+++ b/tests/Test/Workflow/SafeWorkflow/Debug.hs
@@ -1,0 +1,301 @@
+{-# LANGUAGE BangPatterns, TypeApplications #-}
+module Test.Workflow.SafeWorkflow.Debug where
+
+import Protolude
+
+import qualified Data.Set as S
+import qualified Data.Map as M
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import Language.FCL.AST (Transition(..), Name(..), makeWorkflowState, startState, endState, wfUnion)
+import Language.FCL.Analysis (inferTransitions)
+import Language.FCL.Parser (parseFile)
+import Language.FCL.Pretty (Pretty(..), vsep)
+import Language.FCL.Reachability.General (completeReachabilityGraph)
+import Language.FCL.Reachability.SplitAndMerge (reachabilityGraph, reverseTransitions, freeChoicePropertyViolations)
+import Language.FCL.Reachability.Definitions (WFError(..), ReachabilityGraph, pprReachabilityGraph)
+
+import Test.Workflow.SafeWorkflow
+import Test.Workflow.SafeWorkflow.Extended
+import Test.Workflow.SafeWorkflow.Examples
+import Test.Workflow.SafeWorkflow.Tests
+
+import Prelude ((!!))
+import Test.QuickCheck
+import Language.FCL.AST (Name(..), Place(..), WorkflowState(..), Transition(..))
+import Language.FCL.Graphviz
+import Language.FCL.Pretty hiding (print)
+import Language.FCL.Debug
+
+import System.Clock
+
+-- witness0 :: ExtendedSW
+-- witness0 = ExtendedSW
+--   { eswSafeWorkflow = Seq { seqLhs = GenXOR { gXorLhsIn = XOR Atom Atom
+--                                             , gXorLhsOut = GenLoop {gLoopIn = Just Atom, gLoopExit = Atom, gLoopOut = Atom}
+--                                             , gXorRhsIn = AND {andBranches = Atom :| [Atom]}
+--                                             , gXorRhsOut = AND {andBranches = Atom :| [Atom,Atom]}
+--                                             , gXorMToRhs = Just (XOR {xorLhs = Atom, xorRhs = XOR {xorLhs = Atom, xorRhs = Atom}})
+--                                             , gXorMToLhs = Just Atom}
+--                           , seqRhs = XOR    { xorLhs = Atom
+--                                             , xorRhs = XOR  { xorLhs = Seq  { seqLhs = AND {andBranches = Atom :| [Atom]}
+--                                                                             , seqRhs = AND {andBranches = Atom :| [Atom,Atom]}
+--                                                                             }
+--                                                             , xorRhs = AND {andBranches = Atom :| [Atom]}
+--                                                             }
+--                                             }
+--                           }
+--   , eswExtraTransitions = S.fromList  [ Arrow (WorkflowState {places = S.fromList [Place {placeName = Name {unName = "1"}}]})
+--                                               (WorkflowState {places = S.fromList [Place {placeName = Name {unName = "6"}}, Place {placeName = Name {unName = "8"}}]})
+--                                       ]
+--   }
+
+-- simplifiedWitness0 :: ExtendedSW
+-- simplifiedWitness0 = ExtendedSW
+--   { eswSafeWorkflow = Seq { seqLhs = GenXOR { gXorLhsIn  = Atom
+--                                             , gXorLhsOut = GenLoop {gLoopIn = Just Atom, gLoopExit = Atom, gLoopOut = Atom}
+--                                             , gXorRhsIn  = AND {andBranches = Atom :| [Atom]}
+--                                             , gXorRhsOut = Atom
+--                                             , gXorMToRhs = Just Atom
+--                                             , gXorMToLhs = Just Atom
+--                                             }
+--                           , seqRhs = Atom
+--                           }
+--   , eswExtraTransitions = S.fromList  [ Arrow (WorkflowState {places = S.fromList [Place {placeName = Name {unName = "1"}}]})
+--                                               (WorkflowState {places = S.fromList [Place {placeName = Name {unName = "6"}}, Place {placeName = Name {unName = "8"}}]})
+--                                       ]
+--   }
+
+-- asd :: [ExtendedFCSW]
+-- asd =
+--   -- FC graph is not smaller (OK) (both take roughly the same amount of time to finish, the the genral algo is faster by a little bit)
+--   [ EFCSW {fcGetESW = ExtendedSW {eswSafeWorkflow = GenXOR {gXorLhsIn = GenXOR {gXorLhsIn = Atom, gXorLhsOut = Atom, gXorRhsIn = Atom, gXorRhsOut = Atom, gXorMToRhs = Nothing, gXorMToLhs = Nothing}, gXorLhsOut = GenXOR {gXorLhsIn = Atom, gXorLhsOut = Atom, gXorRhsIn = Atom, gXorRhsOut = Atom, gXorMToRhs = Just Atom, gXorMToLhs = Nothing}, gXorRhsIn = XOR {xorLhs = Atom, xorRhs = Atom}, gXorRhsOut = GenXOR {gXorLhsIn = Atom, gXorLhsOut = Atom, gXorRhsIn = Atom, gXorRhsOut = Atom, gXorMToRhs = Just Atom, gXorMToLhs = Just Atom}, gXorMToRhs = Just (Seq {seqLhs = Atom, seqRhs = Atom}), gXorMToLhs = Nothing}, eswExtraTransitions = S.fromList [Arrow (WorkflowState {places = S.fromList [Place {placeName = Name {unName = "9"}}]}) (WorkflowState {places = S.fromList [PlaceStart,Place {placeName = Name {unName = "1"}},Place {placeName = Name {unName = "2"}}]})]}}
+--   -- FC graph is not smaller (OK)
+--   , EFCSW {fcGetESW = ExtendedSW {eswSafeWorkflow = AND {andBranches = GenLoop {gLoopIn = Nothing, gLoopExit = Atom, gLoopOut = Atom} :| [XOR {xorLhs = Atom, xorRhs = XOR {xorLhs = Atom, xorRhs = Atom}}]}, eswExtraTransitions = S.fromList [Arrow (WorkflowState {places = S.fromList [Place {placeName = Name {unName = "1"}}]}) (WorkflowState {places = S.fromList [Place {placeName = Name {unName = "4"}}]}),Arrow (WorkflowState {places = S.fromList [Place {placeName = Name {unName = "3"}}]}) (WorkflowState {places = S.fromList [Place {placeName = Name {unName = "1"}}]})]}}
+--   -- FC graph is not smaller (OK)
+--   , EFCSW {fcGetESW = ExtendedSW {eswSafeWorkflow = GenXOR {gXorLhsIn = Atom, gXorLhsOut = Atom, gXorRhsIn = Atom, gXorRhsOut = Atom, gXorMToRhs = Nothing, gXorMToLhs = Just Atom}, eswExtraTransitions = S.fromList [Arrow (WorkflowState {places =S.fromList [Place {placeName = Name {unName = "1"}}]}) (WorkflowState {places =S.fromList [PlaceStart,Place {placeName = Name {unName = "x"}}]})]}}
+
+--   -- FC graph is not smaller
+--   , EFCSW {fcGetESW = ExtendedSW {eswSafeWorkflow = XOR {xorLhs = XOR {xorLhs = Atom, xorRhs = Atom}, xorRhs = GenLoop {gLoopIn = Nothing, gLoopExit = Atom, gLoopOut = Atom}}, eswExtraTransitions = S.fromList [Arrow (WorkflowState {places = S.fromList [PlaceStart]}) (WorkflowState {places = S.fromList [PlaceStart,Place {placeName = Name {unName = "x"}}]}),Arrow (WorkflowState {places = S.fromList [Place {placeName = Name {unName = "x"}}]}) (WorkflowState {places = S.fromList [PlaceEnd]})]}}
+--   ]
+
+-- qwe :: [ExtendedFCSW]
+-- qwe =
+--   [ fromSafeWorkflow $ AND {andBranches = GenLoop {gLoopIn = Nothing, gLoopExit = Atom, gLoopOut = AND {andBranches = Atom :| [Atom]}} :| [Atom]}
+--   , fromSafeWorkflow $ AND {andBranches = XOR {xorLhs = AND {andBranches = Atom :| [Atom]}, xorRhs = GenLoop {gLoopIn = Nothing, gLoopExit = Atom, gLoopOut = Atom}} :| [Atom]}
+--   , fromSafeWorkflow $ AND {andBranches = Atom :| [GenLoop {gLoopIn = Nothing, gLoopExit = AND {andBranches = Atom :| [Atom]}, gLoopOut = Atom}]}
+--   , fromSafeWorkflow $ GenLoop {gLoopIn = Nothing, gLoopExit = Atom, gLoopOut = GenXOR {gXorLhsIn = Atom, gXorLhsOut = Atom, gXorRhsIn = Atom, gXorRhsOut = Atom, gXorMToRhs = Nothing, gXorMToLhs = Nothing}}
+--   , fromSafeWorkflow $ GenLoop {gLoopIn = Nothing, gLoopExit = Atom, gLoopOut = AND {andBranches = Atom :| []}}
+--   , fromSafeWorkflow $ AND {andBranches = Atom :| [GenLoop {gLoopIn = Nothing, gLoopExit = Atom, gLoopOut = AND {andBranches = Atom :| []}}]}
+--   -- global loop
+--   , EFCSW {fcGetESW = ExtendedSW {eswSafeWorkflow = AND {andBranches = Atom :| [Atom,Atom]}, eswExtraTransitions = S.fromList [Arrow (WorkflowState {places = S.fromList [Place {placeName = Name {unName = "1"}}]}) (WorkflowState {places = S.fromList [PlaceStart]})]}}
+--   -- global skip to terminal
+--   , EFCSW {fcGetESW = ExtendedSW {eswSafeWorkflow = XOR (Seq Atom Atom) (AND2 Atom Atom), eswExtraTransitions = S.fromList [Arrow (WorkflowState {places = S.fromList [Place {placeName = Name {unName = "2"}}]}) (WorkflowState {places = S.fromList [PlaceEnd]})]}}
+--   , EFCSW {fcGetESW = ExtendedSW {eswSafeWorkflow = XOR (AND2 Atom Atom) (Seq Atom Atom), eswExtraTransitions = S.fromList [Arrow (WorkflowState {places = S.fromList [Place {placeName = Name {unName = "2"}}]}) (WorkflowState {places = S.fromList [PlaceEnd]})]}}
+--   -- global skip to non-terminal
+--   , EFCSW {fcGetESW = ExtendedSW {eswSafeWorkflow = XOR (Seq Atom Atom) (AND2 Atom Atom), eswExtraTransitions = S.fromList [Arrow (WorkflowState {places = S.fromList [Place {placeName = Name {unName = "2"}}]}) (WorkflowState {places = S.fromList [Place {placeName = Name {unName = "1"}}]})]}}
+--   , EFCSW {fcGetESW = ExtendedSW {eswSafeWorkflow = XOR (AND2 Atom Atom) (Seq Atom Atom), eswExtraTransitions = S.fromList [Arrow (WorkflowState {places = S.fromList [Place {placeName = Name {unName = "1"}}]}) (WorkflowState {places = S.fromList [Place {placeName = Name {unName = "5"}}]})]}}
+--   , fromSafeWorkflow $ AND {andBranches = GenXOR {gXorLhsIn = Atom, gXorLhsOut = Atom, gXorRhsIn = Atom, gXorRhsOut = Atom, gXorMToRhs = Just (AND {andBranches = Atom :| []}), gXorMToLhs = Just (AND {andBranches = Atom :| [Atom]})} :| [Atom]}
+
+--   , EFCSW {fcGetESW = ExtendedSW {eswSafeWorkflow = Atom, eswExtraTransitions = S.fromList [Arrow (WorkflowState {places = S.fromList [PlaceStart]}) (WorkflowState {places = S.fromList [Place {placeName = Name {unName = "a"}},Place {placeName = Name {unName = "f"}},Place {placeName = Name {unName = "p"}}]}),Arrow (WorkflowState {places = S.fromList [Place {placeName = Name {unName = "a"}},Place {placeName = Name {unName = "f"}},Place {placeName = Name {unName = "p"}}]}) (WorkflowState {places = S.fromList [PlaceStart]})]}}
+--   , EFCSW {fcGetESW = ExtendedSW {eswSafeWorkflow = Atom, eswExtraTransitions = S.fromList [Arrow (WorkflowState {places = S.fromList [PlaceStart]}) (WorkflowState {places = S.fromList [Place {placeName = Name {unName = "a"}},Place {placeName = Name {unName = "f"}},Place {placeName = Name {unName = "p"}}]}),Arrow (WorkflowState {places = S.fromList [Place {placeName = Name {unName = "a"}},Place {placeName = Name {unName = "f"}},Place {placeName = Name {unName = "p"}}]}) (WorkflowState {places = S.fromList [PlaceStart]})]}}
+--   , EFCSW {fcGetESW = ExtendedSW {eswSafeWorkflow = Atom, eswExtraTransitions = S.fromList [Arrow (WorkflowState {places = S.fromList [PlaceStart]}) (WorkflowState {places = S.fromList [Place {placeName = Name {unName = "f"}},Place {placeName = Name {unName = "fz"}}]}),Arrow (WorkflowState {places = S.fromList [Place {placeName = Name {unName = "f"}},Place {placeName = Name {unName = "fw"}}]}) (WorkflowState {places = S.fromList [PlaceEnd]}), Arrow (WorkflowState {places = S.fromList [Place {placeName = Name {unName = "fz"}}]}) (WorkflowState {places = S.fromList [Place {placeName = Name {unName = "fw"}}]})]}}
+--   , EFCSW {fcGetESW = ExtendedSW {eswSafeWorkflow = Atom, eswExtraTransitions = S.fromList [Arrow (WorkflowState {places = S.fromList [PlaceStart]}) (WorkflowState {places = S.fromList [Place {placeName = Name {unName = "f"}},Place {placeName = Name {unName = "fw"}}]}),Arrow (WorkflowState {places = S.fromList [Place {placeName = Name {unName = "f"}}]}) (WorkflowState {places = S.fromList [Place {placeName = Name {unName = "f"}}]}), Arrow (WorkflowState {places = S.fromList [Place {placeName = Name {unName = "fw"}}]}) (WorkflowState {places = S.fromList [Place {placeName = Name {unName = "fw"}}]})]}}
+
+--   -- AND loops back to global state but the workflow is sound
+--   , EFCSW {fcGetESW = ExtendedSW {eswSafeWorkflow = AND {andBranches = Atom :| [Atom,Atom]}, eswExtraTransitions = S.fromList [Arrow (WorkflowState {places = S.fromList [Place {placeName = Name {unName = "5"}}]}) (WorkflowState {places = S.fromList [PlaceStart]})]}}
+--   , EFCSW {fcGetESW = ExtendedSW {eswSafeWorkflow = AND {andBranches = Atom :| [Atom]},      eswExtraTransitions = S.fromList [Arrow (WorkflowState {places = S.fromList [Place {placeName = Name {unName = "3"}}]}) (WorkflowState {places = S.fromList [PlaceStart]})]}}
+
+--   -- global skip
+--   , EFCSW {fcGetESW = ExtendedSW {eswSafeWorkflow = AND {andBranches = Atom :| [Atom]}, eswExtraTransitions = S.fromList [Arrow (WorkflowState {places = S.fromList [PlaceStart]}) (WorkflowState {places = S.fromList [Place {placeName = Name {unName = "2"}}, Place {placeName = Name {unName = "4"}}]})]}}
+
+--   -- local jump back to dead-end state
+--   , EFCSW $ ExtendedSW
+--       (Seq (AND2 Atom Atom) Atom) $
+--       S.fromList
+--         [ Arrow (makeWorkflowState [Name "1"]) (makeWorkflowState [Name "3"])
+
+--         ]
+--   -- indirect jump back to AND branch
+--   , EFCSW $ ExtendedSW
+--       (Seq (AND2 Atom Atom) Atom) $
+--       S.fromList
+--         [ Arrow (makeWorkflowState [Name "1"]) (makeWorkflowState [Name "6", Name "7"])
+  --       , Arrow (makeWorkflowState [Name "6"]) (makeWorkflowState [Name "3"])
+  --       , Arrow (makeWorkflowState [Name "7"]) (makeWorkflowState [Name "5"])
+  --       ]
+  -- -- direct jump back to AND branch
+  -- , EFCSW $ ExtendedSW
+  --     (Seq (AND2 Atom Atom) Atom) $
+  --     S.fromList
+  --       [ Arrow (makeWorkflowState [Name "1"]) (makeWorkflowState [Name "3", Name "5"])
+  --       ]
+  -- -- incorrect direct jump back to AND branch
+  -- , EFCSW $ ExtendedSW
+  --     (Seq (AND2 Atom Atom) Atom) $
+  --     S.fromList
+  --       [ Arrow (makeWorkflowState [Name "1"]) (makeWorkflowState [Name "3"] `wfUnion` startState)
+  --       ]
+  -- ]
+
+-- xcv :: [Set Transition]
+-- xcv = map S.fromList
+--   [ -- global exit to state with applicable transitions
+--     [ Arrow startState (makeWorkflowState [Name "1"])
+--     , Arrow (makeWorkflowState [Name "1"]) (makeWorkflowState [Name "2", Name "3"])
+--     , Arrow (makeWorkflowState [Name "2", Name "3"]) (makeWorkflowState [Name "2", Name "3"])
+--     , Arrow (makeWorkflowState [Name "2"]) startState
+--     , Arrow (makeWorkflowState [Name "3"]) endState
+--     ]
+
+--   ]
+
+fromSafeWorkflow :: SafeWorkflow -> ExtendedFCSW
+fromSafeWorkflow swf = EFCSW $ ExtendedSW swf mempty
+
+eswToTransitions :: ExtendedSW -> [Transition]
+eswToTransitions ExtendedSW{..} = (sort . constructTransitions $ eswSafeWorkflow) ++ (S.toList eswExtraTransitions)
+
+printESW :: FilePath -> ExtendedSW -> IO ()
+printESW path = workflowWriteSVG path . Transitions . eswToTransitions
+
+printSW :: FilePath -> SafeWorkflow -> IO ()
+printSW path = workflowWriteSVG path . Transitions . sort . constructTransitions
+
+corg :: ExtendedSW -> ReachabilityGraph
+corg = reverseTransitions . rg
+
+rg :: ExtendedSW -> ReachabilityGraph
+rg esw = {- trace (show . pprRG $ (errs, graph) :: [Char]) -} graph where
+  (errs, graph) = reachabilityGraph . S.fromList . extendedWorkflowTransitions $ esw
+
+  pprRG :: (Set WFError, ReachabilityGraph) -> Doc
+  pprRG (errs, graph) = ppr errs <$$> pprReachabilityGraph graph
+
+crg :: ExtendedSW -> ReachabilityGraph
+crg esw = {- trace (show . pprRG $ (errs, graph) :: [Char]) -} graph where
+  (errs, graph) = completeReachabilityGraph . S.fromList . extendedWorkflowTransitions $ esw
+
+  pprRG :: (Set WFError, ReachabilityGraph) -> Doc
+  pprRG (errs, graph) = ppr errs <$$> pprReachabilityGraph graph
+
+fileRg :: FilePath -> IO ()
+fileRg fp = do
+  script <- parseFile fp
+  let trs = inferTransitions script
+      (errs, graph) = reachabilityGraph $ S.fromList trs
+  print $ pprReachabilityGraph graph
+  print $ ppr errs
+
+onlySafe :: ExtendedSW -> ExtendedSW
+onlySafe esw = esw { eswExtraTransitions = mempty }
+
+-- NOTE: could fail
+noErrorsFC :: ExtendedFCSW -> Bool
+noErrorsFC efcsw
+  | esw <- fcGetESW efcsw
+  , (freeChoiceErrs, _) <- checkWithBoth esw
+  = force freeChoiceErrs `seq` True
+
+-- NOTE: could fail
+noErrorsGeneral :: ExtendedFCSW -> Bool
+noErrorsGeneral efcsw
+  | esw <- fcGetESW efcsw
+  , (_, generalErrs) <- checkWithBoth esw
+  = force generalErrs `seq` True
+
+testFC :: Int -> IO ()
+testFC n = do
+  swfs <- generate (vectorOf 1000 $ resize n $ arbitrary :: Gen [SafeWorkflow])
+  forM_ swfs $ \swf -> do
+    Protolude.print swf
+    let sound = null $ fst $ checkWithBoth (fcGetESW $ fromSafeWorkflow swf)
+    let sound = isSafeWorkflowSound_SplitAndMerge swf
+    Protolude.print sound
+    Protolude.print "----------"
+
+-- TODO: delete these
+isXOR (XOR _ _) = True
+isXOR _ = False
+
+checkSizeIO :: Int -> IO Int
+checkSizeIO n = do
+  swf <- generate ((resize n $ arbitrary) :: Gen SafeWorkflow)
+  return $ length $ constructTransitions swf
+
+printNamedNets :: [(ExtendedFCSW, [Char])] -> IO ()
+printNamedNets = mapM_ (\(eswFC, name) -> printESW ("./Extended/" <> name) $ fcGetESW eswFC)
+
+
+------------------
+-- Benchmarking --
+------------------
+
+benchmark :: IO ()
+benchmark = forM_ [6..20] $ \size -> do
+  (splitAndMergeTime, generalTime) <- measure 10000 size
+  print $ "size: " <> show size <> "  -  " <> "no. workflows: " <> (show 10000 :: Text)
+  print $ ppr $ splitAndMergeTime
+  print $ ppr $ generalTime
+  print "-----------"
+
+measure :: Int -> Int -> IO (Double, Double)
+measure trials size = do
+  workflows <- generate (vectorOf trials $ resize size $ arbitrary @SafeWorkflow)
+  force workflows `seq` return ()
+  start <- getTime Monotonic
+  force (map isSafeWorkflowSound_SplitAndMerge workflows) `seq` return ()
+  splitAndMergeDone <- getTime Monotonic
+  force (map isSafeWorkflowSound_General workflows) `seq` return ()
+  generalDone <- getTime Monotonic
+  -- print $ ppr $ Sec $ splitAndMergeDone - start
+  -- print $ ppr $ Sec $ generalDone - splitAndMergeDone
+  return ( toDouble $ splitAndMergeDone - start
+         , toDouble $ generalDone - splitAndMergeDone
+         )
+
+benchmarkExtended :: IO ()
+benchmarkExtended = forM_ [6..20] $ \size -> do
+  (splitAndMergeTime, generalTime) <- measureExtended 10000 size
+  print $ "size: " <> show size <> "  -  " <> "no. workflows: " <> (show 10000 :: Text)
+  print $ ppr $ splitAndMergeTime
+  print $ ppr $ generalTime
+  print "-----------"
+
+measureExtended :: Int -> Int -> IO (Double, Double)
+measureExtended trials size = do
+  workflows <- generate (vectorOf trials $ resize size $ arbitrary @ExtendedFCSW)
+  force workflows `seq` return ()
+  start <- getTime Monotonic
+  force (map (fst . checkWithBoth . fcGetESW) workflows) `seq` return ()
+  splitAndMergeDone <- getTime Monotonic
+  print "SAM DONE"
+  force (map (snd . checkWithBoth . fcGetESW) workflows) `seq` return ()
+  generalDone <- getTime Monotonic
+  print "GEN DONE"
+  return ( toDouble $ splitAndMergeDone - start
+         , toDouble $ generalDone - splitAndMergeDone
+         )
+
+newtype Sec a = Sec a
+  deriving (Eq, Ord, Show)
+
+toDouble :: TimeSpec -> Double
+toDouble TimeSpec{..} = fromIntegral sec + (fromIntegral nsec / 10^9 :: Double)
+
+instance Pretty (Sec TimeSpec) where
+  ppr (Sec t) = ppr $ toDouble t
+
+multiLayerComm :: SafeWorkflow
+multiLayerComm = GenACF $ M.fromList
+  [ (SWArrow Entry (P 1), [Atom])
+  , (SWArrow (P 1) (P 3), [Atom])
+  , (SWArrow (P 3) Exit, [Atom])
+  , (SWArrow Entry (P 2), [Atom])
+  , (SWArrow (P 2) (P 4), [Atom])
+  , (SWArrow (P 4) Exit, [Atom])
+  , (SWArrow (P 1) (P 2), [Atom])
+  , (SWArrow (P 3) (P 4), [Atom])
+  ]

--- a/tests/Test/Workflow/SafeWorkflow/Examples.hs
+++ b/tests/Test/Workflow/SafeWorkflow/Examples.hs
@@ -41,17 +41,11 @@ namedBasicNets =
   , ( "Loop"
     , Loop Atom Atom Atom
     )
-  , ( "completeGenXOR"
-    , GenXOR Atom Atom Atom Atom (Just Atom) (Just Atom)
-    )
   , ( "toRightGenXOR"
-    , GenXOR Atom Atom Atom Atom (Just Atom) Nothing
+    , GenXOR Atom Atom Atom Atom Atom
     )
   , ( "toLeftGenXOR"
-    , GenXOR Atom Atom Atom Atom Nothing (Just Atom)
-    )
-  , ( "simpleGenXOR"
-    , GenXOR Atom Atom Atom Atom Nothing Nothing
+    , GenXOR Atom Atom Atom Atom Atom
     )
   ]
 
@@ -86,11 +80,11 @@ namedExampleNets =
     , Seq Atom (XOR (Seq Atom (SimpleLoop (XOR3 Atom Atom Atom) (XOR (Seq Atom (XOR3 (Seq Atom Atom) (Seq Atom Atom) (Seq Atom Atom))) (Loop Atom (Seq Atom Atom) (XOR Atom (Seq Atom Atom)))))) Atom)
     )
   , ( "gas-forward-simple"
-    ,  Seq Atom (XOR (GenXOR Atom (SimpleLoop Atom Atom) Atom Atom (Just Atom) Nothing) Atom)
+    ,  Seq Atom (XOR (GenXOR Atom (SimpleLoop Atom Atom) Atom Atom Atom) Atom)
     )
   , ( "gas-forward"
     , let gasForwardNominationSubNet = SimpleLoop Atom (Seq (AND2 Atom (SimpleLoop Atom Atom)) (SimpleLoop Atom Atom)) in
-        Seq Atom (XOR (GenXOR Atom (SimpleLoop Atom Atom) Atom gasForwardNominationSubNet (Just Atom) Nothing) Atom)
+        Seq Atom (XOR (GenXOR Atom (SimpleLoop Atom Atom) Atom gasForwardNominationSubNet Atom) Atom)
     )
   ]
 
@@ -104,15 +98,23 @@ namedArbitraryNets = zipWith (\id net -> ("arbitrary-" <> show id, net)) [0..] a
 arbitraryNets :: [SafeWorkflow]
 arbitraryNets =
   [ Atom
-  , XOR {xorLhs = AND {andBranches = Atom :| [Atom]}, xorRhs = XOR {xorLhs = Atom, xorRhs = Atom}}
-  , Seq {seqLhs = GenLoop {gLoopIn = Nothing, gLoopExit = GenLoop {gLoopIn = Just Atom, gLoopExit = Atom, gLoopOut = Atom}, gLoopOut = GenXOR {gXorLhsIn = Atom, gXorLhsOut = Atom, gXorRhsIn = Atom, gXorRhsOut = Atom, gXorMToRhs = Just Atom, gXorMToLhs = Just Atom}}, seqRhs = XOR {xorLhs = GenLoop {gLoopIn = Just Atom, gLoopExit = Atom, gLoopOut = Atom}, xorRhs = GenLoop {gLoopIn = Just Atom, gLoopExit = Atom, gLoopOut = Atom}}}
-  , Seq {seqLhs = GenLoop {gLoopIn = Nothing, gLoopExit = XOR {xorLhs = Atom, xorRhs = XOR {xorLhs = Atom, xorRhs = Atom}}, gLoopOut = AND {andBranches = Atom :| [Atom]}}, seqRhs = AND {andBranches = GenLoop {gLoopIn = Nothing, gLoopExit = Atom, gLoopOut = Atom} :| [GenXOR {gXorLhsIn = Atom, gXorLhsOut = Atom, gXorRhsIn = Atom, gXorRhsOut = Atom, gXorMToRhs = Nothing, gXorMToLhs = Nothing},GenLoop {gLoopIn = Nothing, gLoopExit = Atom, gLoopOut = Atom}]}}
-  , GenLoop {gLoopIn = Nothing, gLoopExit = GenXOR {gXorLhsIn = Atom, gXorLhsOut = Atom, gXorRhsIn = Atom, gXorRhsOut = Atom, gXorMToRhs = Just Atom, gXorMToLhs = Nothing}, gLoopOut = GenLoop {gLoopIn = Nothing, gLoopExit = AND {andBranches = Atom :| [Atom,Atom,Atom]}, gLoopOut = GenLoop {gLoopIn = Nothing, gLoopExit = AND {andBranches = Atom :| [Atom,Atom]}, gLoopOut = GenLoop {gLoopIn = Nothing, gLoopExit = Atom, gLoopOut = Atom}}}}
-  , AND {andBranches = Seq {seqLhs = Seq {seqLhs = Atom, seqRhs = Atom}, seqRhs = XOR {xorLhs = Atom, xorRhs = XOR {xorLhs = Atom, xorRhs = Atom}}} :| [GenXOR {gXorLhsIn = Atom, gXorLhsOut = Atom, gXorRhsIn = Atom, gXorRhsOut = Atom, gXorMToRhs = Just Atom, gXorMToLhs = Just Atom},XOR {xorLhs = AND {andBranches = Atom :| [Atom]}, xorRhs = XOR {xorLhs = Seq {seqLhs = Atom, seqRhs = Atom}, xorRhs = Atom}}]}
-  , AND {andBranches = XOR {xorLhs = GenXOR {gXorLhsIn = Atom, gXorLhsOut = Atom, gXorRhsIn = Atom, gXorRhsOut = Atom, gXorMToRhs = Just Atom, gXorMToLhs = Just Atom}, xorRhs = GenLoop {gLoopIn = Just (GenLoop {gLoopIn = Just Atom, gLoopExit = Atom, gLoopOut = Atom}), gLoopExit = XOR {xorLhs = Atom, xorRhs = Atom}, gLoopOut = GenXOR {gXorLhsIn = Atom, gXorLhsOut = Atom, gXorRhsIn = Atom, gXorRhsOut = Atom, gXorMToRhs = Just Atom, gXorMToLhs = Just Atom}}} :| [XOR {xorLhs = GenXOR {gXorLhsIn = Atom, gXorLhsOut = Atom, gXorRhsIn = Atom, gXorRhsOut = Atom, gXorMToRhs = Just Atom, gXorMToLhs = Just Atom}, xorRhs = AND {andBranches = XOR {xorLhs = Atom, xorRhs = XOR {xorLhs = Atom, xorRhs = Atom}} :| [XOR {xorLhs = Atom, xorRhs = XOR {xorLhs = Atom, xorRhs = Atom}}]}}]}
-  , Seq {seqLhs = GenLoop {gLoopIn = Nothing, gLoopExit = GenLoop {gLoopIn = Just (AND {andBranches = Atom :| [Atom]}), gLoopExit = Atom, gLoopOut = Seq {seqLhs = Atom, seqRhs = Atom}}, gLoopOut = XOR {xorLhs = GenXOR {gXorLhsIn = Atom, gXorLhsOut = Atom, gXorRhsIn = Atom, gXorRhsOut = Atom, gXorMToRhs = Just Atom, gXorMToLhs = Just Atom}, xorRhs = Atom}}, seqRhs = XOR {xorLhs = Atom, xorRhs = XOR {xorLhs = XOR {xorLhs = Atom, xorRhs = XOR {xorLhs = Atom, xorRhs = Atom}}, xorRhs = XOR {xorLhs = Atom, xorRhs = XOR {xorLhs = Atom, xorRhs = Atom}}}}}
-  , XOR {xorLhs = GenLoop {gLoopIn = Nothing, gLoopExit = XOR {xorLhs = AND {andBranches = Seq {seqLhs = Atom, seqRhs = Atom} :| [Seq {seqLhs = Atom, seqRhs = Atom}]}, xorRhs = Seq {seqLhs = XOR {xorLhs = Atom, xorRhs = XOR {xorLhs = Atom, xorRhs = Atom}}, seqRhs = GenLoop {gLoopIn = Nothing, gLoopExit = Atom, gLoopOut = Atom}}}, gLoopOut = AND {andBranches = XOR {xorLhs = XOR {xorLhs = Atom, xorRhs = XOR {xorLhs = Atom, xorRhs = Atom}}, xorRhs = Atom} :| [Seq {seqLhs = XOR {xorLhs = Atom, xorRhs = XOR {xorLhs = Atom, xorRhs = Atom}}, seqRhs = AND {andBranches = Atom :| [Atom,Atom]}}]}}, xorRhs = XOR {xorLhs = Seq {seqLhs = Atom, seqRhs = AND {andBranches = Atom :| [Atom,Atom,Atom]}}, xorRhs = XOR {xorLhs = AND {andBranches = Atom :| [Atom,Atom,Atom,Atom]}, xorRhs = XOR {xorLhs = GenXOR {gXorLhsIn = Atom, gXorLhsOut = Atom, gXorRhsIn = Atom, gXorRhsOut = Atom, gXorMToRhs = Just Atom, gXorMToLhs = Just Atom}, xorRhs = GenLoop {gLoopIn = Just Atom, gLoopExit = Atom, gLoopOut = Atom}}}}}
-  , AND {andBranches = AND {andBranches = XOR {xorLhs = AND {andBranches = Atom :| [Atom]}, xorRhs = Atom} :| [XOR {xorLhs = Seq {seqLhs = AND {andBranches = Atom :| [Atom]}, seqRhs = XOR {xorLhs = Atom, xorRhs = XOR {xorLhs = Atom, xorRhs = Atom}}}, xorRhs = Atom}]} :| [XOR {xorLhs = GenXOR {gXorLhsIn = Atom, gXorLhsOut = Atom, gXorRhsIn = Atom, gXorRhsOut = Atom, gXorMToRhs = Just Atom, gXorMToLhs = Just Atom}, xorRhs = GenLoop {gLoopIn = Just (GenXOR {gXorLhsIn = Atom, gXorLhsOut = Atom, gXorRhsIn = Atom, gXorRhsOut = Atom, gXorMToRhs = Just Atom, gXorMToLhs = Nothing}), gLoopExit = XOR {xorLhs = Atom, xorRhs = XOR {xorLhs = Atom, xorRhs = Atom}}, gLoopOut = XOR {xorLhs = Atom, xorRhs = XOR {xorLhs = Atom, xorRhs = Atom}}}}]}
+  , XOR (AND {andBranches = Atom :| [Atom]}) (XOR Atom Atom)
+  -- NOTE: cannot be expressed with GenACF
+  -- , Seq {seqLhs = GenLoop {gLoopIn = Nothing, gLoopExit = GenLoop {gLoopIn = Just Atom, gLoopExit = Atom, gLoopOut = Atom}, gLoopOut = GenXOR {gXorLhsIn = Atom, gXorLhsOut = Atom, gXorRhsIn = Atom, gXorRhsOut = Atom, gXorMToRhs = Just Atom, gXorMToLhs = Just Atom}}, seqRhs = XOR {xorLhs = GenLoop {gLoopIn = Just Atom, gLoopExit = Atom, gLoopOut = Atom}, xorRhs = GenLoop {gLoopIn = Just Atom, gLoopExit = Atom, gLoopOut = Atom}}}
+  -- TODO: reenable this
+  -- , Seq {seqLhs = GenLoop {gLoopIn = Nothing, gLoopExit = XOR {xorLhs = Atom, xorRhs = XOR {xorLhs = Atom, xorRhs = Atom}}, gLoopOut = AND {andBranches = Atom :| [Atom]}}, seqRhs = AND {andBranches = GenLoop {gLoopIn = Nothing, gLoopExit = Atom, gLoopOut = Atom} :| [XOR (Seq Atom Atom) (Seq Atom Atom), GenLoop {gLoopIn = Nothing, gLoopExit = Atom, gLoopOut = Atom}]}}
+  -- TODO: reenable this
+  -- , GenLoop {gLoopIn = Nothing, gLoopExit = GenXOR {gXorLhsIn = Atom, gXorLhsOut = Atom, gXorRhsIn = Atom, gXorRhsOut = Atom, gXorLhsToRhs = Just Atom}, gLoopOut = GenLoop {gLoopIn = Nothing, gLoopExit = AND {andBranches = Atom :| [Atom,Atom,Atom]}, gLoopOut = GenLoop {gLoopIn = Nothing, gLoopExit = AND {andBranches = Atom :| [Atom,Atom]}, gLoopOut = GenLoop {gLoopIn = Nothing, gLoopExit = Atom, gLoopOut = Atom}}}}
+  -- NOTE: cannot be expressed with GenACF
+  -- , AND {andBranches = Seq {seqLhs = Seq {seqLhs = Atom, seqRhs = Atom}, seqRhs = XOR {xorLhs = Atom, xorRhs = XOR {xorLhs = Atom, xorRhs = Atom}}} :| [GenXOR {gXorLhsIn = Atom, gXorLhsOut = Atom, gXorRhsIn = Atom, gXorRhsOut = Atom, gXorMToRhs = Just Atom, gXorMToLhs = Just Atom},XOR {xorLhs = AND {andBranches = Atom :| [Atom]}, xorRhs = XOR {xorLhs = Seq {seqLhs = Atom, seqRhs = Atom}, xorRhs = Atom}}]}
+  -- NOTE: cannot be expressed with GenACF
+  -- , AND {andBranches = XOR {xorLhs = GenXOR {gXorLhsIn = Atom, gXorLhsOut = Atom, gXorRhsIn = Atom, gXorRhsOut = Atom, gXorMToRhs = Just Atom, gXorMToLhs = Just Atom}, xorRhs = GenLoop {gLoopIn = Just (GenLoop {gLoopIn = Just Atom, gLoopExit = Atom, gLoopOut = Atom}), gLoopExit = XOR {xorLhs = Atom, xorRhs = Atom}, gLoopOut = GenXOR {gXorLhsIn = Atom, gXorLhsOut = Atom, gXorRhsIn = Atom, gXorRhsOut = Atom, gXorMToRhs = Just Atom, gXorMToLhs = Just Atom}}} :| [XOR {xorLhs = GenXOR {gXorLhsIn = Atom, gXorLhsOut = Atom, gXorRhsIn = Atom, gXorRhsOut = Atom, gXorMToRhs = Just Atom, gXorMToLhs = Just Atom}, xorRhs = AND {andBranches = XOR {xorLhs = Atom, xorRhs = XOR {xorLhs = Atom, xorRhs = Atom}} :| [XOR {xorLhs = Atom, xorRhs = XOR {xorLhs = Atom, xorRhs = Atom}}]}}]}
+  -- NOTE: cannot be expressed with GenACF
+  -- , Seq {seqLhs = GenLoop {gLoopIn = Nothing, gLoopExit = GenLoop {gLoopIn = Just (AND {andBranches = Atom :| [Atom]}), gLoopExit = Atom, gLoopOut = Seq {seqLhs = Atom, seqRhs = Atom}}, gLoopOut = XOR {xorLhs = GenXOR {gXorLhsIn = Atom, gXorLhsOut = Atom, gXorRhsIn = Atom, gXorRhsOut = Atom, gXorMToRhs = Just Atom, gXorMToLhs = Just Atom}, xorRhs = Atom}}, seqRhs = XOR {xorLhs = Atom, xorRhs = XOR {xorLhs = XOR {xorLhs = Atom, xorRhs = XOR {xorLhs = Atom, xorRhs = Atom}}, xorRhs = XOR {xorLhs = Atom, xorRhs = XOR {xorLhs = Atom, xorRhs = Atom}}}}}
+  -- NOTE: cannot be expressed with GenACF
+  -- , XOR {xorLhs = GenLoop {gLoopIn = Nothing, gLoopExit = XOR {xorLhs = AND {andBranches = Seq {seqLhs = Atom, seqRhs = Atom} :| [Seq {seqLhs = Atom, seqRhs = Atom}]}, xorRhs = Seq {seqLhs = XOR {xorLhs = Atom, xorRhs = XOR {xorLhs = Atom, xorRhs = Atom}}, seqRhs = GenLoop {gLoopIn = Nothing, gLoopExit = Atom, gLoopOut = Atom}}}, gLoopOut = AND {andBranches = XOR {xorLhs = XOR {xorLhs = Atom, xorRhs = XOR {xorLhs = Atom, xorRhs = Atom}}, xorRhs = Atom} :| [Seq {seqLhs = XOR {xorLhs = Atom, xorRhs = XOR {xorLhs = Atom, xorRhs = Atom}}, seqRhs = AND {andBranches = Atom :| [Atom,Atom]}}]}}, xorRhs = XOR {xorLhs = Seq {seqLhs = Atom, seqRhs = AND {andBranches = Atom :| [Atom,Atom,Atom]}}, xorRhs = XOR {xorLhs = AND {andBranches = Atom :| [Atom,Atom,Atom,Atom]}, xorRhs = XOR {xorLhs = GenXOR {gXorLhsIn = Atom, gXorLhsOut = Atom, gXorRhsIn = Atom, gXorRhsOut = Atom, gXorMToRhs = Just Atom, gXorMToLhs = Just Atom}, xorRhs = GenLoop {gLoopIn = Just Atom, gLoopExit = Atom, gLoopOut = Atom}}}}}
+  -- NOTE: cannot be expressed with GenACF
+  -- , AND {andBranches = AND {andBranches = XOR {xorLhs = AND {andBranches = Atom :| [Atom]}, xorRhs = Atom} :| [XOR {xorLhs = Seq {seqLhs = AND {andBranches = Atom :| [Atom]}, seqRhs = XOR {xorLhs = Atom, xorRhs = XOR {xorLhs = Atom, xorRhs = Atom}}}, xorRhs = Atom}]} :| [XOR {xorLhs = GenXOR {gXorLhsIn = Atom, gXorLhsOut = Atom, gXorRhsIn = Atom, gXorRhsOut = Atom, gXorMToRhs = Just Atom, gXorMToLhs = Just Atom}, xorRhs = GenLoop {gLoopIn = Just (GenXOR {gXorLhsIn = Atom, gXorLhsOut = Atom, gXorRhsIn = Atom, gXorRhsOut = Atom, gXorLhsToRhs = Just Atom}), gLoopExit = XOR {xorLhs = Atom, xorRhs = XOR {xorLhs = Atom, xorRhs = Atom}}, gLoopOut = XOR {xorLhs = Atom, xorRhs = XOR {xorLhs = Atom, xorRhs = Atom}}}}]}
   ]
 
 -- | Cases generated by QuickCheck that revealed bugs in the Split-and-Merge


### PR DESCRIPTION
Generalizing safe workflows
======================

Generalizing safe workflows with acyclic control-flows. Instead of having `XOR`, `Seq` and the special generalization of `XOR` called GenXOR`, we introduce a new construct called _general acyclic control-flow_. This is a construct which contains arrows and places. The transitions in the arrows can be any arbitrary safe workflow, just like in any other construct, but the arrows cannot loop nor go backwards.

This allows for a more expressive model and also gets rid of the hidden loop inside `GenXOR`. 