### PR TITLE
Enhance callable methods API

### DIFF
--- a/src/HTTP/FCL/SwaggerSchema.hs
+++ b/src/HTTP/FCL/SwaggerSchema.hs
@@ -122,7 +122,7 @@ instance ToSchema AST.Value where
       ]
       False
 
-instance ToSchema NotCallableReason where
+instance ToSchema NotCallableReason
 
 instance ToSchema Contract where
   declareNamedSchema _ = do
@@ -155,15 +155,8 @@ instance ToSchema Metadata where
   declareNamedSchema _ =
     pure $ NamedSchema (Just "Metadata") (toSchema (Proxy :: Proxy (Map Text Text)))
 
-instance ToSchema CallableMethods where
-  declareNamedSchema _ = do
-    -- Use Text instead of Type because of the custom JSON instance of PermittedCallers
-    m <- declareSchemaRef @(PermittedCallers, [(Name, Text)]) Proxy
-    pure $ NamedSchema (Just "CallableMethods")
-      $ mempty { _schemaParamSchema = mempty { _paramSchemaType = SwaggerObject }
-               , _schemaAdditionalProperties = Just $ AdditionalPropertiesSchema m
-               }
 
+instance ToSchema CallableMethods
 instance ToSchema PermittedCallers where
   declareNamedSchema _ = do
     t <- declareSchemaRef @Text Proxy

--- a/src/HTTP/FCL/SwaggerSchema.hs
+++ b/src/HTTP/FCL/SwaggerSchema.hs
@@ -143,7 +143,6 @@ instance ToSchema Contract where
       ]
       True
 
-instance ToSchema InvalidMethodName
 instance ToSchema GlobalStorage where
   declareNamedSchema _ =
     pure $ NamedSchema (Just "GlobalStorage") (toSchema (Proxy :: Proxy Storage))

--- a/src/HTTP/FCL/SwaggerSchema.hs
+++ b/src/HTTP/FCL/SwaggerSchema.hs
@@ -122,6 +122,8 @@ instance ToSchema AST.Value where
       ]
       False
 
+instance ToSchema NotCallableReason where
+
 instance ToSchema Contract where
   declareNamedSchema _ = do
     time <- declareSchemaRef @Timestamp Proxy

--- a/src/Language/FCL/Address.hs
+++ b/src/Language/FCL/Address.hs
@@ -16,6 +16,7 @@ import Language.FCL.Encoding as Encoding
 import Language.FCL.Pretty
 import Data.Aeson (ToJSON(..), FromJSON(..))
 import Data.Serialize as S (Serialize(..))
+import Data.Swagger (ToSchema)
 import Data.Binary (Binary(..))
 
 import Language.FCL.Orphans ()
@@ -31,6 +32,8 @@ data AddrType
 newtype Address (t :: AddrType)
   = Address ByteString
   deriving (Eq, Ord, Show, Generic, Hash.Hashable, Binary, Serialize, FromJSON, ToJSON)
+
+instance ToSchema (Address a)
 
 instance Pretty (Address 'AAccount) where
   ppr (Address bs) = ppr bs

--- a/src/Language/FCL/Address.hs
+++ b/src/Language/FCL/Address.hs
@@ -16,7 +16,6 @@ import Language.FCL.Encoding as Encoding
 import Language.FCL.Pretty
 import Data.Aeson (ToJSON(..), FromJSON(..))
 import Data.Serialize as S (Serialize(..))
-import Data.Swagger (ToSchema)
 import Data.Binary (Binary(..))
 
 import Language.FCL.Orphans ()
@@ -33,7 +32,6 @@ newtype Address (t :: AddrType)
   = Address ByteString
   deriving (Eq, Ord, Show, Generic, Hash.Hashable, Binary, Serialize, FromJSON, ToJSON)
 
-instance ToSchema (Address a)
 
 instance Pretty (Address 'AAccount) where
   ppr (Address bs) = ppr bs

--- a/src/Language/FCL/Contract.hs
+++ b/src/Language/FCL/Contract.hs
@@ -42,6 +42,7 @@ import qualified Language.FCL.Storage as Storage
 import qualified Language.FCL.Utils as Utils
 
 import Language.FCL.AST
+import Language.FCL.Error (NotCallableReason(..))
 import Language.FCL.Pretty ((<+>), ppr)
 import qualified Language.FCL.Pretty as Pretty
 import qualified Language.FCL.Parser as Parser
@@ -179,14 +180,6 @@ data CallableMethods
   deriving (Show, Generic, ToJSON)
 
 instance Arbitrary CallableMethods where
-  arbitrary = genericArbitraryU
-
-data NotCallableReason
-  = NotCallableWorkflowState
-  | NotCallablePrecondition
-  deriving (Show, Generic, ToJSON)
-
-instance Arbitrary NotCallableReason where
   arbitrary = genericArbitraryU
 
 -------------------------------------------------------------------------------

--- a/src/Language/FCL/Contract.hs
+++ b/src/Language/FCL/Contract.hs
@@ -184,9 +184,11 @@ instance ToJSON CallableMethods where
   toJSON = callableMethodsJSON
 
 callableMethodsJSON :: CallableMethods -> A.Value
-callableMethodsJSON (CallableMethods m) = toJSON
-                    . Map.mapKeys Pretty.prettyPrint
-                    . Map.map (bimap callersJSON (map (bimap Pretty.prettyPrint Pretty.prettyPrint))) $ m
+callableMethodsJSON (CallableMethods m)
+  = toJSON
+  . Map.mapKeys Pretty.prettyPrint
+  . Map.map (bimap callersJSON (map (bimap Pretty.prettyPrint Pretty.prettyPrint)))
+  $ m
 
 -------------------------------------------------------------------------------
 

--- a/src/Language/FCL/Contract.hs
+++ b/src/Language/FCL/Contract.hs
@@ -51,7 +51,7 @@ import Data.Serialize (Serialize)
 import qualified Data.Map.Strict as Map
 import qualified Data.Binary as B
 
-import Data.Aeson (ToJSON(..), (.=), (.:))
+import Data.Aeson (ToJSON(..), (.=), (.:), sumEncoding, genericToJSON, SumEncoding(..), defaultOptions)
 import Data.Aeson.Types (typeMismatch)
 import qualified Data.Aeson as A
 
@@ -174,7 +174,10 @@ data CallableMethods
     { cmCallableMethods    :: [LName]
     , cmNotCallableMethods :: [(LName, NonEmpty NotCallableReason)]
     }
-  deriving (Show, Generic, ToJSON)
+  deriving (Show, Generic)
+
+instance ToJSON CallableMethods where
+  toJSON = genericToJSON (defaultOptions { sumEncoding = ObjectWithSingleField })
 
 instance Arbitrary CallableMethods where
   arbitrary = genericArbitraryU

--- a/src/Language/FCL/Contract.hs
+++ b/src/Language/FCL/Contract.hs
@@ -171,7 +171,7 @@ callersJSON callers =
 -- access restriction expressions associated with contract methods.
 data CallableMethods
   = MkCallableMethods
-    { cmCallableMethods    :: [LName] -- Map.Map Name (PermittedCallers, [(Name, Type)])
+    { cmCallableMethods    :: [LName]
     , cmNotCallableMethods :: [(LName, NonEmpty NotCallableReason)]
     }
   deriving (Show, Generic, ToJSON)

--- a/src/Language/FCL/Error.hs
+++ b/src/Language/FCL/Error.hs
@@ -45,9 +45,9 @@ data EvalFail
   | NoTransactionContext Loc Text       -- ^ Asked for a bit of transaction context without a transaction context
   | PatternMatchFailure Value Loc        -- ^ No matching pattern
   -- Precondition errors, all of the form `PrecNotSatX Method <expected> <actual>`
-  | PrecNotSatAfter Method DateTime DateTime
-  | PrecNotSatBefore Method DateTime DateTime
-  | PrecNotSatCaller Method (Set (Address AAccount)) (Address AAccount)
+  | PrecNotSatAfter LName DateTime DateTime
+  | PrecNotSatBefore LName DateTime DateTime
+  | PrecNotSatCaller LName (Set (Address AAccount)) (Address AAccount)
   deriving (Eq, Show, Generic, Serialize)
 
 instance Arbitrary EvalFail where
@@ -81,16 +81,16 @@ instance Pretty EvalFail where
                                                           <$$+> ppr msg
     NoTransactionContext loc msg       -> "Invalid transaction context info request at" <+> ppr loc <> ":"
                                        <$$+> ppr msg
-    PrecNotSatAfter m dtExpected dtActual ->
-      "Temporal precondition for calling method" <+> ppr (methodName m) <+> "not satisfied."
+    PrecNotSatAfter methodName dtExpected dtActual ->
+      "Temporal precondition for calling method" <+> ppr methodName <+> "not satisfied."
       <$$+> "Method only callable after: " <+> ppr (VDateTime dtExpected)
         <+> ". Actual date-time:" <+> ppr (VDateTime dtActual)
-    PrecNotSatBefore m dtExpected dtActual ->
-      "Temporal precondition for calling method" <+> ppr (methodName m) <+> "not satisfied."
+    PrecNotSatBefore methodName dtExpected dtActual ->
+      "Temporal precondition for calling method" <+> ppr methodName <+> "not satisfied."
       <$$+> "Method only callable before: " <+> ppr (VDateTime dtExpected)
         <+> ". Actual date-time:" <+> ppr (VDateTime dtActual)
-    PrecNotSatCaller m setAccExpected accActual ->
-      "Unauthorized to call method" <+> sqppr (methodName m) <> "."
+    PrecNotSatCaller methodName setAccExpected accActual ->
+      "Unauthorized to call method" <+> sqppr methodName <> "."
           <$$+> vcat
           [ "Transaction issuer: " <+> ppr accActual
           , "Authorized accounts: " <+> setOf setAccExpected

--- a/src/Language/FCL/Error.hs
+++ b/src/Language/FCL/Error.hs
@@ -16,7 +16,7 @@ module Language.FCL.Error (
 
 import Protolude hiding (Overflow, Underflow, DivideByZero)
 
-import Data.Aeson (ToJSON(..))
+import Data.Aeson (ToJSON(..), sumEncoding, genericToJSON, SumEncoding(..), defaultOptions)
 import Data.Serialize (Serialize)
 import Test.QuickCheck
 import Generic.Random
@@ -106,7 +106,10 @@ data NotCallableReason
   | ErrPrecAfter DateTime DateTime
   | ErrPrecBefore DateTime DateTime
   | ErrPrecCaller (Set (Address AAccount)) (Address AAccount)
-  deriving (Eq, Show, Generic, ToJSON, Serialize)
+  deriving (Eq, Show, Generic, Serialize)
+
+instance ToJSON NotCallableReason where
+  toJSON = genericToJSON (defaultOptions { sumEncoding = ObjectWithSingleField })
 
 instance Arbitrary NotCallableReason where
   arbitrary = genericArbitraryU

--- a/src/Language/FCL/Error.hs
+++ b/src/Language/FCL/Error.hs
@@ -18,7 +18,6 @@ import Protolude hiding (Overflow, Underflow, DivideByZero)
 
 import Data.Aeson (ToJSON(..))
 import Data.Serialize (Serialize)
-import Data.Swagger (ToSchema)
 import Test.QuickCheck
 import Generic.Random
 
@@ -111,17 +110,3 @@ data NotCallableReason
 
 instance Arbitrary NotCallableReason where
   arbitrary = genericArbitraryU
-
-instance ToSchema NotCallableReason
-
--- data InvalidMethodName
---   = MethodDoesNotExist Name
---   | MethodNotCallable  Name WorkflowState
---   deriving (Eq, Show, Generic, Serialize)
-
--- instance Arbitrary InvalidMethodName where
---   arbitrary = genericArbitraryU
-
-  -- instance Pretty.Pretty InvalidMethodName where
---   ppr (MethodDoesNotExist nm) = "Method does not exist:" <+> ppr nm
---   ppr (MethodNotCallable nm state) = "Method" <+> ppr nm <+> "not callable in current state:" <+> ppr state

--- a/src/Language/FCL/Eval.hs
+++ b/src/Language/FCL/Eval.hs
@@ -171,7 +171,7 @@ insertTempVar (Name var) val = modify' $ \evalState ->
 -- | Extends the temp storage with temporary variable updates. Emulates a
 -- closure environment for evaluating the body of helper functions by
 -- assigning values to argument names. Effectively ad-hoc substitution.
-localTempStorage :: [(Name,Value)] -> EvalM world a -> (EvalM world) a
+localTempStorage :: [(Name,Value)] -> EvalM world a -> EvalM world a
 localTempStorage varVals evalM = do
   currTempStorage <- tempStorage <$> get
   let store = Map.fromList (map (first (Key . unName)) varVals)
@@ -185,7 +185,7 @@ localTempStorage varVals evalM = do
 
 -- | Warning: This function will throw an exception on a non-existent helper, as
 -- this indicates the typechecker failed to spot an undefined function name.
-lookupHelper :: LName -> (EvalM world) Helper
+lookupHelper :: LName -> EvalM world Helper
 lookupHelper lhnm = do
   helpers <- currentHelpers <$> ask
   case List.find ((==) lhnm . helperName) helpers of
@@ -193,7 +193,7 @@ lookupHelper lhnm = do
     Just helper -> pure helper
 
 -- | Emit a delta updating  the state of a global reference.
-updateGlobalVar :: Name -> Value -> (EvalM world) ()
+updateGlobalVar :: Name -> Value -> EvalM world ()
 updateGlobalVar v@(Name var) val = do
     modify' $ \evalState ->
       evalState { globalStorage = updateVar (globalStorage evalState) }
@@ -201,55 +201,55 @@ updateGlobalVar v@(Name var) val = do
   where
     updateVar = Map.update (\_ -> Just val) (Key var)
 
-setWorld :: world -> (EvalM world) ()
+setWorld :: world -> EvalM world ()
 setWorld w = modify' $ \evalState -> evalState { worldState = w }
 
 -- | Update the evaluate state.
-updateState :: WorkflowState -> (EvalM world) ()
+updateState :: WorkflowState -> EvalM world ()
 updateState newState = modify' $ \s -> s { workflowState = newState }
 
 -- | Get the evaluation state
-getState :: (EvalM world) WorkflowState
+getState :: EvalM world WorkflowState
 getState = gets workflowState
 
-setCurrentMethod :: Maybe Method -> (EvalM world) ()
+setCurrentMethod :: Maybe Method -> EvalM world ()
 setCurrentMethod m = modify' $ \s -> s { currentMethod = m }
 
 -- | Emit a delta
-emitDelta :: Delta.Delta -> (EvalM world) ()
+emitDelta :: Delta.Delta -> EvalM world ()
 emitDelta delta = modify' $ \s -> s { deltas = deltas s ++ [delta] }
 
 -- | Lookup variable in scope
-lookupVar :: Name -> (EvalM world) (Maybe Value)
+lookupVar :: Name -> EvalM world (Maybe Value)
 lookupVar var = do
   gVar <- lookupGlobalVar var
   case gVar of
     Nothing  -> lookupTempVar var
     Just val -> return $ Just val
 
-transactionCtxField :: Loc -> Text -> (TransactionCtx -> a) -> (EvalM world) a
+transactionCtxField :: Loc -> Text -> (TransactionCtx -> a) -> EvalM world a
 transactionCtxField loc errMsg getField = do
   mfield <- fmap getField . currentTxCtx <$> ask
   case mfield of
     Nothing -> throwError $ NoTransactionContext loc errMsg
     Just field -> pure field
 
-currBlockTimestamp :: Loc -> (EvalM world) Timestamp
+currBlockTimestamp :: Loc -> EvalM world Timestamp
 currBlockTimestamp loc = do
   let errMsg = "Cannot get timestamp without a transaction context"
   transactionCtxField loc errMsg transactionBlockTs
 
-currentBlockIdx :: Loc -> (EvalM world) Int64
+currentBlockIdx :: Loc -> EvalM world Int64
 currentBlockIdx loc = do
   let errMsg = "Cannot get block index without a transaction context"
   transactionCtxField loc errMsg transactionBlockIdx
 
-currentTxHash :: Loc -> (EvalM world) (Hash.Hash Encoding.Base16ByteString)
+currentTxHash :: Loc -> EvalM world (Hash.Hash Encoding.Base16ByteString)
 currentTxHash loc = do
   let errMsg = "Cannot get current transaction hash without a transaction context"
   transactionCtxField loc errMsg transactionHash
 
-currentTxIssuer :: Loc -> (EvalM world) (Address AAccount)
+currentTxIssuer :: Loc -> EvalM world (Address AAccount)
 currentTxIssuer loc = do
   let errMsg = "Cannot get current transaction issuer without a transaction context"
   transactionCtxField loc errMsg transactionIssuer
@@ -274,7 +274,7 @@ instance Crypto.MonadRandom (EvalM world) where
   getRandomBytes = lift . lift . lift . Crypto.getRandomBytes
 
 -- | Run the evaluation monad.
-execEvalM :: EvalCtx -> EvalState world -> (EvalM world) a -> IO (Either Error.EvalFail (EvalState world))
+execEvalM :: EvalCtx -> EvalState world -> EvalM world a -> IO (Either Error.EvalFail (EvalState world))
 execEvalM evalCtx evalState
   = handleArithError
   . runRandom
@@ -283,7 +283,7 @@ execEvalM evalCtx evalState
   . flip runReaderT evalCtx
 
 -- | Run the evaluation monad.
-runEvalM :: EvalCtx -> EvalState world -> (EvalM world) a -> IO (Either Error.EvalFail (a, EvalState world))
+runEvalM :: EvalCtx -> EvalState world -> EvalM world a -> IO (Either Error.EvalFail (a, EvalState world))
 runEvalM evalCtx evalState
   = handleArithError
   . runRandom
@@ -556,7 +556,7 @@ accessRecordField c vs fd dict
     Nothing -> panic "`accessRecordField` was given invalid data"
 
 -- | Evaluate a binop and two Fractional Num args
-evalBinOpF :: (Fractional a, Ord a) => BinOp -> (a -> Value) -> a -> a -> (EvalM world) Value
+evalBinOpF :: (Fractional a, Ord a) => BinOp -> (a -> Value) -> a -> a -> EvalM world Value
 evalBinOpF Add constr a b = pure $ constr (a + b)
 evalBinOpF Sub constr a b = pure $ constr (a - b)
 evalBinOpF Mul constr a b = pure $ constr (a * b)
@@ -574,7 +574,7 @@ evalBinOpF bop c a b = panicInvalidBinOp bop (c a) (c b)
 evalPrim
   :: forall world.
   (World world, Show (AccountError' world), Show (AssetError' world))
-  => Loc -> PrimOp -> [LExpr] -> (EvalM world) Value
+  => Loc -> PrimOp -> [LExpr] -> EvalM world Value
 evalPrim loc ex args = case ex of
   Now               -> do
     currDatetime <- posixMicroSecsToDatetime <$> currBlockTimestamp loc
@@ -764,7 +764,7 @@ evalPrim loc ex args = case ex of
 
 evalAssetPrim
   :: forall world. (World world, Show (AccountError' world), Show (AssetError' world))
-  => Loc -> Prim.AssetPrimOp -> [LExpr] -> (EvalM world) Value
+  => Loc -> Prim.AssetPrimOp -> [LExpr] -> EvalM world Value
 evalAssetPrim loc assetPrimOp args =
   case assetPrimOp of
 
@@ -922,7 +922,7 @@ evalAssetPrim loc assetPrimOp args =
 
 
 evalMapPrim :: (World world, Show (AccountError' world), Show (AssetError' world))
-  => Prim.MapPrimOp -> [LExpr] -> (EvalM world) Value
+  => Prim.MapPrimOp -> [LExpr] -> EvalM world Value
 evalMapPrim mapPrimOp args =
   case mapPrimOp of
     Prim.MapInsert -> do
@@ -950,7 +950,7 @@ evalMapPrim mapPrimOp args =
           pure $ VMap (Map.insert k newVal mapVal)
 
 evalSetPrim :: (World world, Show (AccountError' world), Show (AssetError' world))
-  => Prim.SetPrimOp -> [LExpr] -> (EvalM world) Value
+  => Prim.SetPrimOp -> [LExpr] -> EvalM world Value
 evalSetPrim setPrimOp args =
   case setPrimOp of
     Prim.SetInsert -> do
@@ -961,7 +961,7 @@ evalSetPrim setPrimOp args =
       pure $ VSet (Set.delete v setVal)
 
 evalCollPrim :: forall world. (World world, Show (AccountError' world), Show (AssetError' world))
-  => Prim.CollPrimOp -> [LExpr] -> (EvalM world) Value
+  => Prim.CollPrimOp -> [LExpr] -> EvalM world Value
 evalCollPrim collPrimOp args =
   case collPrimOp of
     Prim.Aggregate -> do
@@ -1021,12 +1021,12 @@ evalCollPrim collPrimOp args =
       CallPrimOpFail loc (Just v) "Cannot call a collection primop on a non-collection value"
 
     -- Map over a collection type (which happen to all implement Traversable)
-    mapColl :: Traversable f => LExpr -> Name -> f Value -> (EvalM world) (f Value)
+    mapColl :: Traversable f => LExpr -> Name -> f Value -> EvalM world (f Value)
     mapColl body nm coll =
       forM coll $ \val ->
         localTempStorage [(nm, val)] (evalLExpr body)
 
-    filterPred :: LExpr -> (Name, Value) -> (EvalM world) Bool
+    filterPred :: LExpr -> (Name, Value) -> EvalM world Bool
     filterPred body var = do
       res <- localTempStorage [var] (evalLExpr body)
       pure $ case res of
@@ -1034,7 +1034,7 @@ evalCollPrim collPrimOp args =
         VBool False -> False
         otherwise -> panicImpossible "Body of helper function used in filter primop did not return Bool"
 
-    foldColl :: LExpr -> (Name, Value) -> Name -> [Value] -> (EvalM world) Value
+    foldColl :: LExpr -> (Name, Value) -> Name -> [Value] -> EvalM world Value
     foldColl fbody (accNm, initVal) argNm vals =
         foldM accum initVal vals
       where
@@ -1045,12 +1045,12 @@ evalCollPrim collPrimOp args =
 
 getAccountAddr
   :: forall world. (World world, Show (AccountError' world), Show (AssetError' world))
-  => LExpr -> (EvalM world) (Address AAccount)
+  => LExpr -> EvalM world (Address AAccount)
 getAccountAddr accExpr = do
   world <- gets worldState
   accountToAddr @world <$> getAccount accExpr
 
-getAccount :: (World world, Show (AccountError' world), Show (AssetError' world)) => LExpr -> (EvalM world) (Account' world)
+getAccount :: (World world, Show (AccountError' world), Show (AssetError' world)) => LExpr -> EvalM world (Account' world)
 getAccount accExpr = do
   ledgerState <- gets worldState
   accAddr <- extractAddrAccount <$> evalLExpr accExpr
@@ -1061,12 +1061,12 @@ getAccount accExpr = do
 
 getAssetAddr
   :: forall world. (World world, Show (AccountError' world), Show (AssetError' world))
-  => LExpr -> (EvalM world) (Address AAsset)
+  => LExpr -> EvalM world (Address AAsset)
 getAssetAddr assetExpr = do
   world <- gets worldState
   assetToAddr @world <$> getAsset assetExpr
 
-getAsset :: (World world, Show (AccountError' world), Show (AssetError' world)) => LExpr -> (EvalM world) (Asset' world)
+getAsset :: (World world, Show (AccountError' world), Show (AssetError' world)) => LExpr -> EvalM world (Asset' world)
 getAsset assetExpr = do
   ledgerState <- gets worldState
   assetAddr   <- extractAddrAsset <$> evalLExpr assetExpr
@@ -1076,7 +1076,7 @@ getAsset assetExpr = do
     Right asset -> pure asset
 
 -- | Check that the method state precondition is a substate of the actual state.
-checkGraph :: (EvalM world) ()
+checkGraph :: EvalM world ()
 checkGraph = do
   Just m <- gets currentMethod
   actualState <- getState
@@ -1086,7 +1086,7 @@ checkGraph = do
 -- | Does not perform typechecking on args supplied, eval should only happen
 -- after typecheck. We don't check whether the input places are satisfied, since
 -- this is done by 'Contract.callableMethods'
-evalMethod :: (World world, Show (AccountError' world), Show (AssetError' world)) => Method -> [Value] -> (EvalM world) Value
+evalMethod :: (World world, Show (AccountError' world), Show (AssetError' world)) => Method -> [Value] -> EvalM world Value
 evalMethod meth@(Method _ _ nm argTyps body) args = do
     setCurrentMethod (Just meth)
     checkPreconditions meth
@@ -1106,13 +1106,13 @@ evalMethod meth@(Method _ _ nm argTyps body) args = do
 -- Methods will only ever be evaluated in the context of a contract on the
 -- ledger. If script methods should be evaluated outside of the context of a
 -- contract, call `evalMethod`.
-eval :: (World world, Show (AccountError' world), Show (AssetError' world)) => Contract.Contract -> Name -> [Value] -> (EvalM world) Value
+eval :: (World world, Show (AccountError' world), Show (AssetError' world)) => Contract.Contract -> Name -> [Value] -> EvalM world Value
 eval c nm args =
   case Contract.lookupContractMethod nm c of
     Right method -> evalMethod method args
     Left err -> throwError (InvalidMethodName err)
 
-noop :: (EvalM world) Value
+noop :: EvalM world Value
 noop = pure VVoid
 
 
@@ -1142,7 +1142,7 @@ data PreconditionsV = PreconditionsV
 
 -- | Succeeds when all preconditions are fulfilled and throws an error otherwise
 -- NB: We assume that we are given a type checked AST
-evalPreconditions :: forall world. (World world, Show (AccountError' world), Show (AssetError' world)) => Method -> (EvalM world) PreconditionsV
+evalPreconditions :: forall world. (World world, Show (AccountError' world), Show (AssetError' world)) => Method -> EvalM world PreconditionsV
 evalPreconditions m = do
   let Preconditions ps = methodPreconditions m
   PreconditionsV
@@ -1150,17 +1150,17 @@ evalPreconditions m = do
     <*> sequence (evalBefore <$> List.lookup PrecBefore ps)
     <*> sequence (evalRole <$> List.lookup PrecRoles ps)
   where
-    evalAfter :: LExpr -> (EvalM world) DateTime
+    evalAfter :: LExpr -> EvalM world DateTime
     evalAfter expr = do
       VDateTime dt <- evalLExpr expr
       pure dt
 
-    evalBefore :: LExpr -> (EvalM world) DateTime
+    evalBefore :: LExpr -> EvalM world DateTime
     evalBefore expr = do
       VDateTime dt <- evalLExpr expr
       pure dt
 
-    evalRole :: LExpr -> (EvalM world) (Set (Address AAccount))
+    evalRole :: LExpr -> EvalM world (Set (Address AAccount))
     evalRole expr = do
       e <- evalLExpr expr
       case e of
@@ -1170,7 +1170,7 @@ evalPreconditions m = do
         VAccount addr -> pure $ Set.singleton addr
         _ -> panicImpossible $ "Could not evaluate role " <> show e
 
-checkPreconditions :: (World world, Show (AccountError' world), Show (AssetError' world)) => Method -> (EvalM world) ()
+checkPreconditions :: (World world, Show (AccountError' world), Show (AssetError' world)) => Method -> EvalM world ()
 checkPreconditions m = do
   PreconditionsV afterV beforeV roleV <- evalPreconditions m
   sequence_
@@ -1197,7 +1197,10 @@ checkPreconditions m = do
         (issuer `elem` accounts)
         (throwError $ PrecNotSatCaller m accounts issuer)
 
-evalCallableMethods :: (World world, Show (AccountError' world), Show (AssetError' world)) => Contract.Contract -> (EvalM world) Contract.CallableMethods
+evalCallableMethods
+  :: (World world, Show (AccountError' world), Show (AssetError' world))
+  => Contract.Contract
+  -> EvalM world Contract.CallableMethods
 evalCallableMethods contract =
     foldM insertCallableMethod (Contract.CallableMethods mempty) (Contract.callableMethods contract)
   where
@@ -1225,7 +1228,7 @@ evalCallableMethods contract =
 -------------------------------------------------------------------------------
 
 {-# INLINE hashValue #-}
-hashValue :: Value -> (EvalM world) ByteString
+hashValue :: Value -> EvalM world ByteString
 hashValue = \case
   VText msg      -> pure (toS msg)
   VNum n         -> pure (show n)
@@ -1290,7 +1293,7 @@ initStorage evalCtx world s@(Script _ defns _ _ _)
     Left err -> die $ show err
     Right state -> pure . GlobalStorage . globalStorage $ state
   where
-    assignGlobal :: Def -> (EvalM world) ()
+    assignGlobal :: Def -> EvalM world ()
     assignGlobal = \case
       GlobalDef type_ _ nm expr -> do
         val <- evalLExpr expr

--- a/src/Language/FCL/SafeWorkflow.hs
+++ b/src/Language/FCL/SafeWorkflow.hs
@@ -121,27 +121,31 @@ data ANDBranch a b = ANDBranch
 -- The transitions in safe workflows can be annotated by any desired information.
 data SafeWorkflow a b
   -- | AND splitting into multiple workflows.
-  = AND { splitAnnot  :: b                            -- ^ Annotation for the AND-split transition
-        , joinAnnot   :: b                            -- ^ Annotation for the AND-join transition
-        , andBranches :: List2 (ANDBranch a b)        -- ^ At least one branch
-        }
+  = AND
+    { splitAnnot  :: b                     -- ^ Annotation for the AND-split transition
+    , joinAnnot   :: b                     -- ^ Annotation for the AND-join transition
+    , andBranches :: List2 (ANDBranch a b) -- ^ At least one branch
+    }
   -- | Looping construct with option to exit from both the body of the loop and the head of the loop.
   -- If the first half of the body is empty, we exit from head, otherwise exit from the body.
-  | GenLoop { exitAnnot :: Maybe a                      -- ^ Annotation of the exit point (place)
-            , gLoopIn   :: Maybe (SafeWorkflow a b)     -- ^ First half of the body of the loop
-            , gLoopExit :: (SafeWorkflow a b)           -- ^ Exit from the loop
-            , gLoopOut  :: (SafeWorkflow a b)           -- ^ Seconds half of the body of the loop
-            }
+  | GenLoop
+    { exitAnnot :: Maybe a                  -- ^ Annotation of the exit point (place)
+    , gLoopIn   :: Maybe (SafeWorkflow a b) -- ^ First half of the body of the loop
+    , gLoopExit :: (SafeWorkflow a b)       -- ^ Exit from the loop
+    , gLoopOut  :: (SafeWorkflow a b)       -- ^ Seconds half of the body of the loop
+    }
   -- | Acyclic control-flow.
   -- It maps arrows to a non-empty list of safe workflows. An arrow represents
   -- the possible ways to transition from a given state to another one. If the list
   -- is not singleton, it represents an XOR-split, multiple ways to exectute the transition.
-  | ACF' { placeAnnots :: PlaceAnnotMap a     -- ^ Anotations for the places in the acyclic control-flow.
-         , acfMap      :: ACFMap a b          -- ^ A mapping describing the structure of the acyclic control-flow.
-         }
+  | ACF'
+    { placeAnnots :: PlaceAnnotMap a -- ^ Anotations for the places in the acyclic control-flow.
+    , acfMap      :: ACFMap a b      -- ^ A mapping describing the structure of the acyclic control-flow.
+    }
   -- | Atom representing a single transition.
-  | Atom { atomAnnot :: b                             -- ^ Annotation for the transitions
-         }
+  | Atom
+    { atomAnnot :: b -- ^ Annotation for the transitions
+    }
   deriving (Eq, Ord, Show, Generic, NFData, Functor, Foldable, Traversable)
 
 
@@ -269,7 +273,7 @@ mkACF annots acfMap = case collectACFErrors annots acfMap of
 -- if the ACF is correct, crashes if it is not.
 unsafeMkACF :: PlaceAnnotMap a -> ACFMap a b -> SafeWorkflow a b
 unsafeMkACF annots = either mkError identity . mkACF annots where
-  mkError acfErrors = panic $ "unsafeMkACF: There were some erros during the construction of the ACF: " <> show acfErrors
+  mkError acfErrors = panic $ "unsafeMkACF: There were some errors during the construction of the ACF: " <> show acfErrors
 
 ---------------------------------------------------
 -- Constructing transitions from @SafeWorkflow@s --

--- a/src/Language/FCL/SafeWorkflow/Builder.hs
+++ b/src/Language/FCL/SafeWorkflow/Builder.hs
@@ -75,7 +75,6 @@ import Language.FCL.Pretty (prettyPrint)
 import qualified Language.FCL.SafeWorkflow          as SW
 import qualified Language.FCL.SafeWorkflow.Editable as Edit
 
--- TODO: currently Options has no impact on any operation, refactor
 -- | Options for running the safe workflow REPL
 data Options = Options
   { logDirectory   :: FilePath
@@ -216,7 +215,7 @@ fromContinuation (cgmIfCond.trCGMetadata -> mCond) = \case
     let thenLabel = ifXorThenLabel `mGuardedBy` mCond
         elseLabel = ifXorElseLabel `mGuardedBy` mCond
     pure $ SW.XOR (SW.Atom thenLabel) (SW.Atom elseLabel)
-  UndetXOR  -> do
+  NonDetXOR  -> do
     lhsId <- gen
     rhsId <- gen
     pure $ SW.XOR (holeWithMCond lhsId mCond) (holeWithMCond rhsId mCond)
@@ -357,7 +356,7 @@ option
   :: TransId
   -> Builder ()
 option holeId = do
-  logAction (replaceHole holeId Edit.UndetXOR)
+  logAction (replaceHole holeId Edit.NonDetXOR)
 
 -- | Replace a hole with a deterministically branching subworkflow.
 conditional
@@ -551,4 +550,3 @@ addGlobalWithDefault
   -> Expr
   -> Builder ()
 addGlobalWithDefault ty name def = addGlobal ty name [] (Just def)
-

--- a/src/Language/FCL/SafeWorkflow/Editable.hs
+++ b/src/Language/FCL/SafeWorkflow/Editable.hs
@@ -46,7 +46,9 @@ import Language.FCL.AST (Name(..), Transition(..), WorkflowState(..), Place(..),
 import Language.FCL.Pretty (Doc, Pretty, ppr, hsep, prettyPrint)
 import Language.FCL.Analysis (inferStaticWorkflowStates)
 import Language.FCL.Graphviz hiding (AnnotatedTransition)
-import Language.FCL.SafeWorkflow.Simple (constructTransitionsWithoutPlaces, constructAnnTransitionsWithoutPlaces)
+import Language.FCL.SafeWorkflow.Simple
+  ( constructTransitionsWithoutPlaces
+  , constructAnnTransitionsWithoutPlaces )
 
 import qualified Language.FCL.SafeWorkflow as SW
 import qualified Language.FCL.Graphviz     as GV
@@ -61,8 +63,12 @@ type TransId = Int
 -- NOTE: global would be for methods (e.g.: preconditions)
 -- | Local transition metadata for code generation
 data CGMetadata = CGMetadata
-  { cgmCode   :: Maybe Expr   -- ^ Code to be generated into the transition (`Nothing` -> `ENoOp`)
-  , cgmIfCond :: Maybe Expr   -- ^ Possible @If@ condition for deterministic branhcing (NOTE: the conditions in a given method should always be mutually exclusive and should always cover the entire event-space)
+  { cgmCode   :: Maybe Expr
+    -- ^ Code to be generated into the transition (`Nothing` -> `ENoOp`)
+  , cgmIfCond :: Maybe Expr
+    -- ^ Possible @If@ condition for deterministic branhcing (NOTE: the
+    -- conditions in a given method should always be mutually exclusive and
+    -- should always cover the entire event-space)
   }
   deriving (Eq, Ord, Show)
 
@@ -76,7 +82,7 @@ data TEditLabel = TEL
   }
   deriving (Eq, Ord, Show)
 
--- | Newtype wrapper for pretty pritning `TEditLabel`s
+-- | Newtype wrapper for pretty printing `TEditLabel`s
 newtype PrettyTLabel = PrettyTLabel TEditLabel
   deriving (Eq, Ord)
 
@@ -150,28 +156,34 @@ data ANDBranchLabels = ANDBranchLabels
 
 -- | `Continuation`s are used to replace holes in `EditableSW`s.
 data Continuation
-  = Atom { atomLabel       :: TEditLabel   -- ^ Label to be put on the transition
-         }
-  | AND  { andSplitLabel    :: TEditLabel            -- ^ Label to be put on the splitting transition
-         , andJoinLabel     :: TEditLabel            -- ^ Label to be put on the joining transition
-         , andBranchLabels  :: List2 ANDBranchLabels -- ^ In and Out annotations of each branch in the AND-split
-         }
+  = Atom
+    { atomLabel :: TEditLabel -- ^ Label to be put on the transition
+    }
+  | AND
+    { andSplitLabel    :: TEditLabel            -- ^ Label to be put on the splitting transition
+    , andJoinLabel     :: TEditLabel            -- ^ Label to be put on the joining transition
+    , andBranchLabels  :: List2 ANDBranchLabels -- ^ In and Out annotations of each branch in the AND-split
+    }
   -- | XOR-spliting by having an @if@ statement in a single method.
-  | IfXOR  { ifXorThenLabel :: TEditLabel   -- ^ Label for the _then_ branch (just for the condition)
-           , ifXorElseLabel :: TEditLabel   -- ^ Label for the _else_ branch (just for the condition)
-           }
-  -- | XOR-spliting by having multiple methods (undetermiinistic semantics).
-  | UndetXOR
-  | SimpleLoop  { sLoopJumpBackLabel    :: TEditLabel -- ^ Label for the jump-back branch    (just for the condition)
-                , sLoopFallThroughLabel :: TEditLabel -- ^ Label for the fall-through branch (just for the condition)
-                }
-  | Loop { exitLabel            :: PEditLabel            -- ^ Label for the exit place
-         , loopBeforeLabel        :: TEditLabel   -- ^ Label for the transition before the breakpoint (just for the condition)
-         , loopAfterLabel :: TEditLabel         -- ^ Label for the transition after the breakpoint (exiting from the loop) (just for the condition)
-         , loopJumpBackLabel    :: TEditLabel    -- ^ Label for the jump-back branch (just for the condition)
-         }
-  | Seq  { inbetweenLabel :: PEditLabel -- ^ Label for the place inbetween the two transitions
-         }
+  | IfXOR
+    { ifXorThenLabel :: TEditLabel -- ^ Label for the _then_ branch (just for the condition)
+    , ifXorElseLabel :: TEditLabel -- ^ Label for the _else_ branch (just for the condition)
+    }
+  -- | XOR-spliting by having multiple methods (nondetermiinistic semantics).
+  | NonDetXOR
+  | SimpleLoop
+    { sLoopJumpBackLabel    :: TEditLabel -- ^ Label for the jump-back branch    (just for the condition)
+    , sLoopFallThroughLabel :: TEditLabel -- ^ Label for the fall-through branch (just for the condition)
+    }
+  | Loop
+    { exitLabel         :: PEditLabel -- ^ Label for the exit place
+    , loopBeforeLabel   :: TEditLabel -- ^ Label for the transition before the breakpoint (just for the condition)
+    , loopAfterLabel    :: TEditLabel -- ^ Label for the transition after the breakpoint (exiting from the loop) (just for the condition)
+    , loopJumpBackLabel :: TEditLabel -- ^ Label for the jump-back branch (just for the condition)
+    }
+  | Seq
+    { inbetweenLabel :: PEditLabel -- ^ Label for the place inbetween the two transitions
+    }
   -- NOTE: Completely incomplete
   | ACF
   deriving (Eq, Ord, Show)

--- a/tests/Test/Script.hs
+++ b/tests/Test/Script.hs
@@ -146,8 +146,8 @@ evalTests = testGroup "eval" <$> sequence
     evalMethod' _ (Left err) _ = pure (Left err)
     evalMethod' evalCtx (Right (contract, evalState)) (Right lname, args) =
         case Contract.lookupContractMethod (locVal lname) contract of
-          Left err -> fail (show err ++ "\n" ++ show contract)
-          Right method -> do
+          Nothing -> fail ("Unknown method " <> (toS . unName . locVal) lname <> "\n" <> show contract)
+          Just method -> do
             eNewEvalState <- Eval.execEvalM
               evalCtx
               evalState

--- a/tests/eval/negative/role-not-authorised.out
+++ b/tests/eval/negative/role-not-authorised.out
@@ -1,3 +1,4 @@
-Unauthorized to call method 'init'.
-   Transaction issuer:  fwBVDsVh8SYQy98CzYpNPcbyTRczVUZ96HszhNRB8Ve
-   Authorized accounts:  {4Stv5gWGt78D3p919HFcKEschSmyGKGrAX2G35xJgdhw,Fw68hsis6JPW4ed3ER1VC959TTf9DqberLxrq5uECKxh}
+Method init is not callable:
+   Transaction issuer not authorised.
+      Transaction issuer:  fwBVDsVh8SYQy98CzYpNPcbyTRczVUZ96HszhNRB8Ve
+      Authorized accounts:  {4Stv5gWGt78D3p919HFcKEschSmyGKGrAX2G35xJgdhw,Fw68hsis6JPW4ed3ER1VC959TTf9DqberLxrq5uECKxh}


### PR DESCRIPTION
This enhances the `callable` methods endpoint as discussed with @faineance and @m-rutter. We will return a list of all callable methods as well as all methods which are not callable, with a reason why they aren’t callable. Currently we are replicating this logic on the application side because Uplink doesn’t give enough information.