### PR TITLE
Callable methods

### DIFF
--- a/src/HTTP/FCL/SwaggerSchema.hs
+++ b/src/HTTP/FCL/SwaggerSchema.hs
@@ -176,7 +176,7 @@ instance ToSchema NotCallableMethod where
   declareNamedSchema _ = do
     t <- declareSchemaRef @Text Proxy
     typ <- declareSchemaRef @Type Proxy
-    reason <- declareSchemaRef @NotCallableReason Proxy
+    reason <- declareSchemaRef @[NotCallableReason] Proxy
     pure $ objectNamedSchema
       "NotCallableMethod"
       [ ("name", t)

--- a/src/HTTP/FCL/SwaggerSchema.hs
+++ b/src/HTTP/FCL/SwaggerSchema.hs
@@ -30,6 +30,7 @@ import Language.FCL.Compile as Compile
 import Language.FCL.Warning as Warning
 import Language.FCL.Effect as Effect
 import Language.FCL.Error as Error
+import qualified Language.FCL.LanguageServerProtocol as LSP
 import Language.FCL.Storage as Storage
 import Language.FCL.Metadata as Metadata
 import Language.FCL.Encoding as Encoding
@@ -39,7 +40,6 @@ import Language.FCL.Reachability.Definitions as Reachability
 import qualified Language.FCL.Duplicate as Dupl
 import Numeric.Lossless.Decimal
 import Numeric.Lossless.Number
-import qualified Language.FCL.LanguageServerProtocol as LSP
 
 -------------------------
 -- Helper functions
@@ -157,6 +157,8 @@ instance ToSchema Metadata where
 
 
 instance ToSchema CallableMethods
+instance ToSchema CallableMethod
+instance ToSchema NotCallableMethod
 instance ToSchema PermittedCallers where
   declareNamedSchema _ = do
     t <- declareSchemaRef @Text Proxy

--- a/src/HTTP/FCL/SwaggerSchema.hs
+++ b/src/HTTP/FCL/SwaggerSchema.hs
@@ -157,8 +157,38 @@ instance ToSchema Metadata where
 
 
 instance ToSchema CallableMethods
-instance ToSchema CallableMethod
-instance ToSchema NotCallableMethod
+instance ToSchema CallableMethod where
+  declareNamedSchema _ = do
+    t <- declareSchemaRef @Text Proxy
+    typ <- declareSchemaRef @Type Proxy
+    pure $ objectNamedSchema
+      "CallableMethod"
+      [ ("name", t)
+      , ("args", Inline $ mempty
+          { _schemaParamSchema = mempty { _paramSchemaType = SwaggerArray }
+          , _schemaAllOf = Just [Inline $ objectSchema [("name", t), ("type", typ)] True]
+          }
+        )
+      ]
+      True
+
+instance ToSchema NotCallableMethod where
+  declareNamedSchema _ = do
+    t <- declareSchemaRef @Text Proxy
+    typ <- declareSchemaRef @Type Proxy
+    reason <- declareSchemaRef @NotCallableReason Proxy
+    pure $ objectNamedSchema
+      "NotCallableMethod"
+      [ ("name", t)
+      , ("args", Inline $ mempty
+          { _schemaParamSchema = mempty { _paramSchemaType = SwaggerArray }
+          , _schemaAllOf = Just [Inline $ objectSchema [("name", t), ("type", typ)] True]
+          }
+        )
+      , ("reason", reason)
+      ]
+      True
+
 instance ToSchema PermittedCallers where
   declareNamedSchema _ = do
     t <- declareSchemaRef @Text Proxy

--- a/src/HTTP/FCL/SwaggerSchema.hs
+++ b/src/HTTP/FCL/SwaggerSchema.hs
@@ -176,7 +176,7 @@ instance ToSchema NotCallableMethod where
   declareNamedSchema _ = do
     t <- declareSchemaRef @Text Proxy
     typ <- declareSchemaRef @Type Proxy
-    reason <- declareSchemaRef @[NotCallableReason] Proxy
+    reasons <- declareSchemaRef @[NotCallableReason] Proxy
     pure $ objectNamedSchema
       "NotCallableMethod"
       [ ("name", t)
@@ -185,7 +185,7 @@ instance ToSchema NotCallableMethod where
           , _schemaAllOf = Just [Inline $ objectSchema [("name", t), ("type", typ)] True]
           }
         )
-      , ("reason", reason)
+      , ("reasons", reasons)
       ]
       True
 

--- a/src/Language/FCL/Contract.hs
+++ b/src/Language/FCL/Contract.hs
@@ -17,6 +17,8 @@ module Language.FCL.Contract (
   callableMethods,
   PermittedCallers(..),
   CallableMethods(..),
+  CallableMethod(..),
+  NotCallableMethod(..),
 
   -- ** Validation
   validateContract,
@@ -169,17 +171,38 @@ callersJSON callers =
 
 -- | Datatype used by Eval.hs to report callable methods after evaluating the
 -- access restriction expressions associated with contract methods.
-data CallableMethods
-  = MkCallableMethods
-    { cmCallableMethods    :: [LName]
-    , cmNotCallableMethods :: [(LName, NonEmpty NotCallableReason)]
-    }
-  deriving (Show, Generic)
+data CallableMethods = CallableMethods
+  { cmCallableMethods    :: [CallableMethod]
+  , cmNotCallableMethods :: [NotCallableMethod]
+  } deriving (Show, Generic)
 
 instance ToJSON CallableMethods where
   toJSON = genericToJSON (defaultOptions { sumEncoding = ObjectWithSingleField })
 
 instance Arbitrary CallableMethods where
+  arbitrary = genericArbitraryU
+
+data CallableMethod = CallableMethod
+  { cmName :: Name
+  , cmArgs :: [Arg]
+  } deriving (Show, Generic)
+
+instance ToJSON CallableMethod where
+  toJSON = genericToJSON (defaultOptions { sumEncoding = ObjectWithSingleField })
+
+instance Arbitrary CallableMethod where
+  arbitrary = genericArbitraryU
+
+data NotCallableMethod = NotCallableMethod
+  { ncmName :: Name
+  , ncmArgs :: [Arg]
+  , ncmReason :: NonEmpty NotCallableReason
+  } deriving (Show, Generic)
+
+instance ToJSON NotCallableMethod where
+  toJSON = genericToJSON (defaultOptions { sumEncoding = ObjectWithSingleField })
+
+instance Arbitrary NotCallableMethod where
   arbitrary = genericArbitraryU
 
 -------------------------------------------------------------------------------

--- a/src/Language/FCL/Contract.hs
+++ b/src/Language/FCL/Contract.hs
@@ -204,11 +204,11 @@ data NotCallableMethod = NotCallableMethod
   } deriving (Show, Generic)
 
 instance ToJSON NotCallableMethod where
-  toJSON (NotCallableMethod name args reason)
+  toJSON (NotCallableMethod name args reasons)
     = A.object [ "name" .= name
                , "args" .= ((\arg@(Arg t ln)
                              -> A.object [ "name" .= locVal ln, "type" .= t]) <$> args)
-               , "reason" .= reason
+               , "reasons" .= reasons
                ]
 
 instance Arbitrary NotCallableMethod where

--- a/src/Language/FCL/Contract.hs
+++ b/src/Language/FCL/Contract.hs
@@ -188,7 +188,11 @@ data CallableMethod = CallableMethod
   } deriving (Show, Generic)
 
 instance ToJSON CallableMethod where
-  toJSON = genericToJSON (defaultOptions { sumEncoding = ObjectWithSingleField })
+  toJSON (CallableMethod name args)
+    = A.object [ "name" .= name
+               , "args" .= ((\arg@(Arg t ln)
+                             -> A.object [ "name" .= locVal ln, "type" .= t]) <$> args)
+               ]
 
 instance Arbitrary CallableMethod where
   arbitrary = genericArbitraryU
@@ -200,7 +204,12 @@ data NotCallableMethod = NotCallableMethod
   } deriving (Show, Generic)
 
 instance ToJSON NotCallableMethod where
-  toJSON = genericToJSON (defaultOptions { sumEncoding = ObjectWithSingleField })
+  toJSON (NotCallableMethod name args reason)
+    = A.object [ "name" .= name
+               , "args" .= ((\arg@(Arg t ln)
+                             -> A.object [ "name" .= locVal ln, "type" .= t]) <$> args)
+               , "reason" .= reason
+               ]
 
 instance Arbitrary NotCallableMethod where
   arbitrary = genericArbitraryU

--- a/src/Language/FCL/Error.hs
+++ b/src/Language/FCL/Error.hs
@@ -44,7 +44,7 @@ data EvalFail
   | CallPrimOpFail Loc (Maybe Value) Text -- ^ Prim op call failed
   | NoTransactionContext Loc Text       -- ^ Asked for a bit of transaction context without a transaction context
   | PatternMatchFailure Value Loc       -- ^ No matching pattern
-  | NotCallable Name NotCallableReason
+  | NotCallable { ncName :: Name, ncArgs :: [Arg], ncReason :: NotCallableReason }
   deriving (Eq, Show, Generic, Serialize)
 
 instance Arbitrary EvalFail where
@@ -78,7 +78,7 @@ instance Pretty EvalFail where
 
     PatternMatchFailure val loc ->
       "No matching pattern for value" <+> sqppr val <+> "at" <+> ppr loc
-    NotCallable methodName reason -> "Method" <+> ppr methodName <+> "is not callable:"
+    NotCallable methodName args reason -> "Method" <+> ppr methodName <+> "is not callable:"
       <$$+> ppr reason
 
 

--- a/src/Language/FCL/Error.hs
+++ b/src/Language/FCL/Error.hs
@@ -44,7 +44,7 @@ data EvalFail
   | CallPrimOpFail Loc (Maybe Value) Text -- ^ Prim op call failed
   | NoTransactionContext Loc Text       -- ^ Asked for a bit of transaction context without a transaction context
   | PatternMatchFailure Value Loc       -- ^ No matching pattern
-  | NotCallable LName NotCallableReason
+  | NotCallable Name NotCallableReason
   deriving (Eq, Show, Generic, Serialize)
 
 instance Arbitrary EvalFail where
@@ -102,10 +102,14 @@ instance Pretty NotCallableReason where
 
 -- | Method Precondition errors, fields of the form  <expected> <actual>`.
 data NotCallableReason
-  = ErrWorkflowState WorkflowState WorkflowState
-  | ErrPrecAfter DateTime DateTime
-  | ErrPrecBefore DateTime DateTime
-  | ErrPrecCaller (Set (Address AAccount)) (Address AAccount)
+  = ErrWorkflowState -- ^ Workflow state precondition error
+    { expectedWS :: WorkflowState, actualWS :: WorkflowState }
+  | ErrPrecAfter -- ^ Method only callable after
+    { expectedAfter :: DateTime, actualAfter :: DateTime }
+  | ErrPrecBefore -- ^ Method only callable before
+    { expectedBefore :: DateTime, actualBefore :: DateTime }
+  | ErrPrecCaller -- ^ Transaction issuer not authorised
+    { expectedCaller :: Set (Address AAccount), actualCaller :: Address AAccount }
   deriving (Eq, Show, Generic, Serialize)
 
 instance ToJSON NotCallableReason where

--- a/src/Language/FCL/Error.hs
+++ b/src/Language/FCL/Error.hs
@@ -44,7 +44,7 @@ data EvalFail
   | CallPrimOpFail Loc (Maybe Value) Text -- ^ Prim op call failed
   | NoTransactionContext Loc Text       -- ^ Asked for a bit of transaction context without a transaction context
   | PatternMatchFailure Value Loc       -- ^ No matching pattern
-  | NotCallable { ncName :: Name, ncArgs :: [Arg], ncReason :: NotCallableReason }
+  | NotCallable Name NotCallableReason
   deriving (Eq, Show, Generic, Serialize)
 
 instance Arbitrary EvalFail where
@@ -78,7 +78,7 @@ instance Pretty EvalFail where
 
     PatternMatchFailure val loc ->
       "No matching pattern for value" <+> sqppr val <+> "at" <+> ppr loc
-    NotCallable methodName args reason -> "Method" <+> ppr methodName <+> "is not callable:"
+    NotCallable methodName reason -> "Method" <+> ppr methodName <+> "is not callable:"
       <$$+> ppr reason
 
 

--- a/src/Language/FCL/Error.hs
+++ b/src/Language/FCL/Error.hs
@@ -109,7 +109,7 @@ data NotCallableReason
   | ErrPrecBefore -- ^ Method only callable before
     { expectedBefore :: DateTime, actualBefore :: DateTime }
   | ErrPrecCaller -- ^ Transaction issuer not authorised
-    { expectedCaller :: Set (Address AAccount), actualCaller :: Address AAccount }
+    { expectedCallers :: Set (Address AAccount), actualCaller :: Address AAccount }
   deriving (Eq, Show, Generic, Serialize)
 
 instance ToJSON NotCallableReason where

--- a/src/Language/FCL/Eval.hs
+++ b/src/Language/FCL/Eval.hs
@@ -1082,7 +1082,7 @@ getAsset assetExpr = do
 evalMethod :: (World world, Show (AccountError' world), Show (AssetError' world)) => Method -> [Value] -> EvalM world Value
 evalMethod meth@(Method _ _ nm argTyps body) args = do
     setCurrentMethod (Just meth)
-    mapM (throwError . NotCallable (locVal nm) argTyps) =<< checkPreconditions meth
+    mapM (throwError . NotCallable (locVal nm)) =<< checkPreconditions meth
     when (numArgs /= numArgsGiven)
          (throwError $ MethodArityError (locVal nm) numArgs numArgsGiven)
     forM_ (zip argNames args) . uncurry $ insertTempVar

--- a/src/Language/FCL/Eval.hs
+++ b/src/Language/FCL/Eval.hs
@@ -1156,9 +1156,14 @@ evalPreconditions m = do
       e <- evalLExpr expr
       case e of
         VSet vAccounts -> do
+          let filteredAccts = Set.filter  (\case
+                                              VAccount _ -> True
+                                              _ -> False
+                                          ) vAccounts
           let accounts = Set.map (\(VAccount a) -> a) vAccounts
           pure accounts
         VAccount addr -> pure $ Set.singleton addr
+        VUndefined -> pure Set.empty
         _ -> panicImpossible $ "Could not evaluate role " <> show e
 
 checkPreconditions
@@ -1166,7 +1171,7 @@ checkPreconditions
   => Method -> EvalM world [NotCallableReason]
 checkPreconditions m = do
     PreconditionsV afterV beforeV roleV <- evalPreconditions m
-    (map catMaybes) . sequence $ catMaybes
+    map catMaybes . sequence $ catMaybes
       [ checkAfter <$> afterV
       , checkBefore <$> beforeV
       , checkRole <$> roleV

--- a/src/Language/FCL/Eval.hs
+++ b/src/Language/FCL/Eval.hs
@@ -1082,7 +1082,7 @@ getAsset assetExpr = do
 evalMethod :: (World world, Show (AccountError' world), Show (AssetError' world)) => Method -> [Value] -> EvalM world Value
 evalMethod meth@(Method _ _ nm argTyps body) args = do
     setCurrentMethod (Just meth)
-    mapM (throwError . NotCallable nm) =<< checkPreconditions meth
+    mapM (throwError . NotCallable (locVal nm)) =<< checkPreconditions meth
     when (numArgs /= numArgsGiven)
          (throwError $ MethodArityError (locVal nm) numArgs numArgsGiven)
     forM_ (zip argNames args) . uncurry $ insertTempVar

--- a/src/Language/FCL/Eval.hs
+++ b/src/Language/FCL/Eval.hs
@@ -1160,8 +1160,7 @@ evalPreconditions m = do
                                               VAccount _ -> True
                                               _ -> False
                                           ) vAccounts
-          let accounts = Set.map (\(VAccount a) -> a) vAccounts
-          pure accounts
+          pure $ Set.map (\(VAccount a) -> a) filteredAccts
         VAccount addr -> pure $ Set.singleton addr
         VUndefined -> pure Set.empty
         _ -> panicImpossible $ "Could not evaluate role " <> show e


### PR DESCRIPTION
Tackle remaining work on the previous Callable Methods PR 

Calling `GET` on `/contracts/{addr}/callable` will return an object like:
```
{
    "cmCallableMethods": [
        {
            "args": [
                {
                    "name": "a",
                    "type": {
                        "TAccount": []
                    }
                },
                {
                    "name": "b",
                    "type": {
                        "TAccount": []
                    }
                }
            ],
            "name": "init"
        },
        {
            "args": [],
            "name": "calculateTotal"
        },
        {
            "args": [],
            "name": "end"
        }
    ],
    "cmNotCallableMethods": [
        {
            "args": [
                {
                    "name": "val",
                    "type": {
                        "TNum": {
                            "NPDecimalPlaces": 0
                        }
                    }
                }
            ],
            "reason": [
                {
                    "ErrPrecCaller": {
                        "actualCaller": "F8XUEiSUDKRhG6Srfft7zB4n8KWEZ6G3YnRg3F5MetVU",
                        "expectedCallers": [
                            "AwS4jxqy79u2HG1Erczzgp63vaa18mMFXcjFyV4iyw9o"
                        ]
                    }
                }
            ],
            "name": "setValueAlice"
        }
    }]
}
```